### PR TITLE
Fix AttributeError in PlantConfigurator and improve test reliability

### DIFF
--- a/pyadm1/configurator/plant_configurator.py
+++ b/pyadm1/configurator/plant_configurator.py
@@ -294,13 +294,17 @@ class PlantConfigurator:
         heating_config.setdefault("heating_id", "heating_main")
 
         # Create components
-        digester = self.add_digester(**digester_config)
+        digester, _ = self.add_digester(**digester_config)
 
-        components = {"digester": digester.component_id}
+        components = {
+            "digester": digester.component_id,
+            "storage": f"{digester.component_id}_storage"
+        }
 
         if chp_config:
             chp = self.add_chp(**chp_config)
             components["chp"] = chp.component_id
+            components["flare"] = f"{chp.component_id}_flare"
 
             if auto_connect:
                 self.auto_connect_digester_to_chp(digester.component_id, chp.component_id)
@@ -357,10 +361,15 @@ class PlantConfigurator:
         chp_config.setdefault("chp_id", "chp_main")
 
         # Create components
-        hydrolysis = self.add_digester(**hydrolysis_config)
-        digester = self.add_digester(**digester_config)
+        hydrolysis, _ = self.add_digester(**hydrolysis_config)
+        digester, _ = self.add_digester(**digester_config)
 
-        components = {"hydrolysis": hydrolysis.component_id, "digester": digester.component_id}
+        components = {
+            "hydrolysis": hydrolysis.component_id,
+            "hydrolysis_storage": f"{hydrolysis.component_id}_storage",
+            "digester": digester.component_id,
+            "digester_storage": f"{digester.component_id}_storage",
+        }
 
         # Connect digesters in series
         if auto_connect:
@@ -370,6 +379,7 @@ class PlantConfigurator:
         if chp_config:
             chp = self.add_chp(**chp_config)
             components["chp"] = chp.component_id
+            components["flare"] = f"{chp.component_id}_flare"
 
             if auto_connect:
                 # Connect both digesters to CHP

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,9 @@ from pathlib import Path
 from typing import List
 
 
+import sys
+from unittest.mock import MagicMock
+
 # Try to import clr and check if .NET runtime is available
 try:
     import clr
@@ -23,6 +26,9 @@ try:
     DOTNET_AVAILABLE = True
 except (ImportError, RuntimeError):
     DOTNET_AVAILABLE = False
+    # Mock clr and biogas for environments without .NET
+    sys.modules["clr"] = MagicMock()
+    sys.modules["biogas"] = MagicMock()
 
 
 def pytest_collection_modifyitems(config, items):


### PR DESCRIPTION
The PlantConfigurator's `add_digester` method returns a tuple `(Digester, str)`, but its internal callers in `create_single_stage_plant` and `create_two_stage_plant` were treating it as if it only returned a `Digester` object. This led to an `AttributeError: 'tuple' object has no attribute 'component_id'`.

This PR fixes this by correctly unpacking the tuple. Additionally, it updates the returned component dictionary to include the IDs of automatically created components (gas storage and CHP flare), which aligns with the expectations of the unit tests.

To facilitate testing in environments without a .NET/Mono runtime (like the sandbox), I've also updated `tests/conftest.py` to mock the `clr` and `biogas` modules if they fail to load. This allows test collection and the execution of unit tests that don't depend on actual simulation logic.

---
*PR created automatically by Jules for task [3240408069940960023](https://jules.google.com/task/3240408069940960023) started by @dgaida*