### PR TITLE
Improve documentation structure and content

### DIFF
--- a/docs/de/examples/basic_digester.md
+++ b/docs/de/examples/basic_digester.md
@@ -1,1 +1,463 @@
-# Examples
+# Basis-Fermenter Beispiel
+n<div align="center">
+  <a href="https://colab.research.google.com/github/dgaida/PyADM1ODE/blob/master/examples/colab_01_basic_digester.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="In Google Colab öffnen (Basis)"></a>
+  <a href="https://colab.research.google.com/github/dgaida/PyADM1ODE/blob/master/examples/colab_02_complex_plant.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="In Google Colab öffnen (Komplex)"></a>
+</div>
+
+Das Beispiel [examples/01_basic_digester.py](https://github.com/dgaida/PyADM1ODE/blob/master/examples/01_basic_digester.py) zeigt die einfachstmögliche PyADM1-Konfiguration: einen einzelnen Fermenter mit Substratzulauf und integriertem Gasspeicher.
+
+## Systemarchitektur
+
+```mermaid
+graph LR
+    %% Substratzulauf
+    Feed[Substratzulauf<br/>Maissilage: 15 m³/d<br/>Rindergülle: 10 m³/d] --> Digester
+
+    %% Hauptfermenter
+    Digester[Fermenter<br/>V_liq: 2000 m³<br/>V_gas: 300 m³<br/>T: 35°C]
+
+    %% Integrierter Gasspeicher
+    Digester -->|Biogasproduktion| Storage[Gasspeicher<br/>Membran-Typ<br/>Kapazität: 300 m³<br/>P: 0.95-1.05 bar]
+
+    %% Biogasaustritt
+    Storage -->|Verfügbares Biogas| Output[Biogasaustritt<br/>~1250 m³/d<br/>CH₄: ~60%]
+
+    %% Notentlüftung
+    Storage -.->|Überschüssiges Gas<br/>wenn voll| Vent[In die Atmosphäre entlüftet<br/>oder Fackel]
+
+    %% Ablauf
+    Digester -->|Ablauf<br/>25 m³/d| Effluent[Gärrestaustrag]
+
+    %% Styling
+    classDef processBox fill:#e1f5fe,stroke:#01579b,stroke-width:2px
+    classDef storageBox fill:#fff3e0,stroke:#e65100,stroke-width:2px
+    classDef inputBox fill:#f1f8e9,stroke:#33691e,stroke-width:2px
+    classDef outputBox fill:#fce4ec,stroke:#880e4f,stroke-width:2px
+
+    class Digester processBox
+    class Storage storageBox
+    class Feed inputBox
+    class Output,Effluent,Vent outputBox
+```
+
+## Übersicht
+
+Das Basis-Fermenter-Beispiel zeigt:
+- Laden von Substratdaten (Feedstock-Management)
+- Erstellen einer einstufigen Biogasanlage
+- Automatische Gasspeicher-Erstellung pro Fermenter
+- Initialisierung aus einer Steady-State-CSV-Datei
+- Durchführen einer kurzen Simulation (5 Tage)
+- Extrahieren und Anzeigen wichtiger Prozessindikatoren
+
+## Anlagenkonfiguration
+
+Die Anlage besteht aus:
+- **1 Fermenter** (2000 m³ Flüssigkeitsvolumen, 300 m³ Gasvolumen)
+- **1 Gasspeicher** (automatisch erstellt, am Fermenter angeschlossen)
+- **Substratzulauf**: Maissilage (15 m³/d) + Rindergülle (10 m³/d)
+
+**Wichtiger Punkt**: Der Gasspeicher wird automatisch durch `PlantConfigurator.add_digester()` erstellt und mit dem Fermenter verbunden. Dies gewährleistet eine realistische Gaspufferung und Druckmanagement.
+
+## Code-Durchgang
+
+### 1. Setup und Imports
+
+```python
+from pyadm1.configurator.plant_builder import BiogasPlant
+from pyadm1.substrates.feedstock import Feedstock
+from pyadm1.core.adm1 import get_state_zero_from_initial_state
+from pyadm1.configurator.plant_configurator import PlantConfigurator
+```
+
+Die wichtigsten Imports sind:
+- `BiogasPlant`: Container für alle Anlagenkomponenten
+- `Feedstock`: Verwaltet Substrateigenschaften und Mischungen
+- `PlantConfigurator`: High-Level-Helper zum Hinzufügen von Komponenten (verwaltet automatisch Gasspeicher)
+- `get_state_zero_from_initial_state`: Lädt den Initialzustand aus einer CSV-Datei
+
+### 2. Feedstock erstellen
+
+```python
+feeding_freq = 48  # Substrat kann alle 48 Stunden geändert werden
+feedstock = Feedstock(feeding_freq=feeding_freq)
+```
+
+Das Feedstock-Objekt lädt Substratparameter aus [`substrate_gummersbach.xml`](https://github.com/dgaida/PyADM1ODE/blob/master/data/substrates/substrate_gummersbach.xml) und verwaltet:
+- Substratzusammensetzung (Weender-Analyse)
+- ADM1-Parameterberechnung
+- Generierung des Zulaufstroms
+
+**Fütterungsfrequenz**: Der Parameter `feeding_freq` (48 Stunden) definiert, wie oft die Steuerung den Substratzulauf anpassen kann. Dies ist wichtig für Optimierungs- und Regelungsanwendungen.
+
+### 3. Initialzustand laden
+
+```python
+initial_state_file = data_path / "digester_initial8.csv"
+adm1_state = get_state_zero_from_initial_state(str(initial_state_file))
+```
+
+Die CSV-Datei für den Initialzustand enthält 37 ADM1-Zustandsvariablen, die einen stabilen Zustand (Steady State) repräsentieren. Dies vermeidet lange Einschwingzeiten, in denen das Modell von unrealistischen Startwerten übergeht.
+
+**ADM1-Zustandsvektor** (37 Variablen):
+- Gelöste Stoffe (0-11): S_su, S_aa, S_fa, S_va, S_bu, S_pro, S_ac, S_h2, S_ch4, S_co2, S_nh4, S_I
+- Partikuläre Stoffe (12-24): X_xc, X_ch, X_pr, X_li, X_su, X_aa, X_fa, X_c4, X_pro, X_ac, X_h2, X_I, X_p
+- Ionen (25-32): S_cation, S_anion, S_va_ion, S_bu_ion, S_pro_ion, S_ac_ion, S_hco3_ion, S_nh3
+- Gasphase (33-36): pi_Sh2, pi_Sch4, pi_Sco2, pTOTAL
+
+### 4. Substratzulauf definieren
+
+```python
+Q_substrates = [15, 10, 0, 0, 0, 0, 0, 0, 0, 0]  # Maissilage und Gülle
+```
+
+Der Zulaufvektor `Q_substrates` gibt die volumetrischen Durchflussraten [m³/d] für jedes in der XML-Datei definierte Substrat an. In diesem Beispiel:
+- Substrat 1 (Maissilage): 15 m³/d
+- Substrat 2 (Rindergülle): 10 m³/d
+- Substrate 3-10: Nicht verwendet (0 m³/d)
+
+**Hydraulische Verweilzeit (HRT)**: 25 m³/d ÷ 2000 m³ = **0,0125 d⁻¹** oder **HRT ≈ 80 Tage**
+
+### 5. Anlage mit PlantConfigurator bauen
+
+```python
+plant = BiogasPlant("Quickstart Anlage")
+configurator = PlantConfigurator(plant, feedstock)
+
+configurator.add_digester(
+    digester_id="main_digester",
+    V_liq=2000.0,
+    V_gas=300.0,
+    T_ad=308.15,  # 35°C mesophil
+    name="Hauptfermenter",
+    load_initial_state=True,
+    initial_state_file=str(initial_state_file),
+    Q_substrates=Q_substrates,
+)
+```
+
+**PlantConfigurator** bietet eine High-Level-API, die:
+- **Automatisch einen Gasspeicher erstellt und an jeden Fermenter anschließt**
+- Die Initialisierung mit ordnungsgemäßer Fehlerprüfung handhabt
+- Komponentenparameter validiert
+- Verbindungen zwischen Komponenten verwaltet
+
+Der Gasspeicher wird erstellt mit:
+- **Typ**: Membranspeicher (Niederdruck, typisch für Biogas)
+- **Kapazität**: Basierend auf dem V_gas Parameter (300 m³)
+- **Druckbereich**: 0.95-1.05 bar (typischer Membranspeicher)
+- **Anfangsfüllung**: 10 % der Kapazität
+
+**Design-Parameter**:
+- `V_liq=2000.0`: Flüssigkeitsvolumen [m³] - typisch für eine mittelgroße landwirtschaftliche Anlage
+- `V_gas=300.0`: Gasraum [m³] - etwa 15 % des Flüssigkeitsvolumens
+- `T_ad=308.15`: Betriebstemperatur [K] = 35°C (mesophiler Bereich)
+
+### 6. Initialisieren und Simulieren
+
+```python
+plant.initialize()
+
+results = plant.simulate(
+    duration=5.0,        # 5 Tage
+    dt=1.0 / 24.0,      # Zeitschritt von 1 Stunde
+    save_interval=1.0    # Ergebnisse täglich speichern
+)
+```
+
+**Simulations-Parameter**:
+- `duration`: Gesamte Simulationszeit [Tage]
+- `dt`: Integrationszeitschritt [Tage]. 1 Stunde (1/24 Tag) ist Standard für ADM1
+- `save_interval`: Wie oft Ergebnisse gespeichert werden [Tage]. Tägliches Speichern reduziert den Speicherverbrauch
+
+**Hinweis**: Der Simulator verwendet einen BDF (Backward Differentiation Formula) Solver, der für steife ODEs wie ADM1 optimiert ist.
+
+**Drei-Pass-Gasfluss-Simulation**:
+1. **Pass 1**: Fermenter produziert Biogas → Gasspeicher empfängt es
+2. **Pass 2**: Gasspeicher aktualisiert den internen Zustand (Druck, Volumen)
+3. **Pass 3**: Gas steht für nachgeschaltete Verbraucher (BHKWs etc.) zur Verfügung
+
+### 7. Ergebnisse anzeigen
+
+```python
+for result in results:
+    comp_results = result["components"]["main_digester"]
+    print(f"Tag {time:.1f}:")
+    print(f"  Biogas:  {comp_results.get('Q_gas', 0):>8.1f} m³/d")
+    print(f"  Methan: {comp_results.get('Q_ch4', 0):>8.1f} m³/d")
+    print(f"  pH:      {comp_results.get('pH', 0):>8.2f}")
+    print(f"  VFA:     {comp_results.get('VFA', 0):>8.2f} g/L")
+    print(f"  TAC:     {comp_results.get('TAC', 0):>8.2f} g/L")
+```
+
+**Wichtige Prozessindikatoren**:
+- **Q_gas**: Gesamtbiogasproduktion [m³/d]
+- **Q_ch4**: Methanproduktion [m³/d]
+- **pH**: Prozess-pH-Wert (optimal: 6,8-7,5)
+- **VFA**: Flüchtige Fettsäuren [g HAc-eq/L] (optimal: <3 g/L)
+- **TAC**: Gesamte Alkalinität [g CaCO₃-eq/L] (optimal: >6 g/L)
+
+**Gasspeicher-Indikatoren** (in den Fermenter-Ergebnissen enthalten):
+- **stored_volume_m3**: Aktuelles Gasvolumen im Speicher [m³]
+- **pressure_bar**: Aktueller Speicherdruck [bar]
+- **vented_volume_m3**: In diesem Zeitschritt abgeblasenes Gas [m³]
+- **Q_gas_supplied_m3_per_day**: Gas, das für Verbraucher verfügbar ist [m³/d]
+
+## Erwartete Ausgabe
+
+Das Ausführen dieses Beispiels erzeugt eine Ausgabe wie:
+
+```
+======================================================================
+PyADM1 Schnellstart-Beispiel (PlantConfigurator Version)
+======================================================================
+
+1. Feedstock wird erstellt...
+2. Initialzustand wird aus CSV geladen...
+   Laden von: digester_initial8.csv
+3. Biogasanlage wird erstellt...
+4. Fermenter wird mit PlantConfigurator hinzugefügt...
+   - Fermenter 'main_digester' erstellt
+   - Gasspeicher 'main_digester_storage' automatisch erstellt
+   - Initialzustand: Geladen aus digester_initial8.csv
+5. Anlage wird initialisiert...
+6. Simulation wird gestartet...
+   Dauer: 5 Tage
+   Zeitschritt: 1 Stunde
+   Speicherintervall: 1 Tag
+
+======================================================================
+SIMULATIONSERGEBNISSE
+======================================================================
+
+6 tägliche Ergebnis-Snapshots generiert
+
+Tag 0.0:
+  Biogas:   1245.3 m³/d
+  Methan:   748.2 m³/d
+  pH:          7.28
+  VFA:         2.34 g/L
+  TAC:         8.45 g/L
+  Speicher:
+    - Volumen: 30.0 m³ (10% voll)
+    - Druck: 0.97 bar
+    - Abgeblasen: 0.0 m³
+
+Tag 1.0:
+  Biogas:   1248.7 m³/d
+  Methan:   750.1 m³/d
+  pH:          7.29
+  VFA:         2.32 g/L
+  TAC:         8.47 g/L
+  Speicher:
+    - Volumen: 82.3 m³ (27% voll)
+    - Druck: 1.01 bar
+    - Abgeblasen: 0.0 m³
+
+...
+
+======================================================================
+ABSCHLUSSZUSAMMENFASSUNG
+======================================================================
+Gesamtbiogasproduktion:  1251.4 m³/d
+Gesamtmethanproduktion: 751.9 m³/d
+Methangehalt:          60.1%
+Prozessstabilität (pH):   7.30
+Speicherauslastung:  35%
+======================================================================
+
+✅ Simulation erfolgreich abgeschlossen!
+
+💾 Konfiguration gespeichert unter: output/quickstart_config.json
+```
+
+## Prozessinterpretation
+
+### Typische Leistungsmetriken
+
+Für diese Konfiguration (25 m³/d Zulauf, HRT ≈ 80 Tage):
+
+| Metrik | Wert | Bewertung |
+|--------|-------|------------|
+| Biogasproduktion | ~1250 m³/d | Gut |
+| Methangehalt | ~60 % | Typisch für landwirtschaftliche Substrate |
+| Spezifischer Gasertrag | ~50 m³/m³ Zulauf | Gut für Mix aus Maissilage + Gülle |
+| pH-Wert | 7,28-7,30 | Optimal (stabil) |
+| VFA | 2,3-2,4 g/L | Gut (weit unter dem Limit von 3 g/L) |
+| TAC | 8,4-8,5 g CaCO₃/L | Exzellente Pufferkapazität |
+| FOS/TAC | ~0,27 | Stabiler Prozess (< 0,3) |
+
+### Prozessstabilitätsindikatoren
+
+**pH-Stabilität**: Der pH-Wert bleibt bei ca. 7,3, was auf Folgendes hindeutet:
+- Gute Pufferkapazität (hoher TAC)
+- Ausgeglichene VFA-Produktion und -Verbrauch
+- Kein Risiko einer Versäuerung
+
+**VFA/TAC-Gleichgewicht**: Ein VFA-Wert von 2,3 g/L bei einem TAC-Wert von 8,4 g/L ergibt einen FOS/TAC ≈ 0,27:
+- < 0,3: Stabiler Prozess
+- 0,3-0,4: Genau beobachten
+- > 0,4: Gefahr der Versäuerung
+
+**Methangehalt**: 60 % CH₄ ist typisch für:
+- Energiepflanzen (Maissilage)
+- Tierische Exkremente
+- Mesophile Vergärung
+
+## Gasspeicher-Verhalten
+
+Der automatisch erstellte Gasspeicher:
+- **Typ**: Niederdruck-Membranspeicher
+- **Kapazität**: ~300 m³ (basierend auf V_gas)
+- **Druckbereich**: 0,95-1,05 bar
+- **Funktion**: Puffert Schwankungen in der Gasproduktion
+- **Sicherheit**: Lässt überschüssiges Gas bei Vollfüllung ab, um Überdruck zu vermeiden
+
+**Speicherdynamik**:
+```python
+'gas_storage': {
+    'stored_volume_m3': 150.0,      # Aktuelles Gasvolumen
+    'pressure_bar': 1.01,            # Aktueller Druck
+    'vented_volume_m3': 0.0,         # In diesem Zeitschritt abgeblasen
+    'utilization': 0.50,             # 50 % gefüllt
+    'Q_gas_supplied_m3_per_day': 1250.0  # Verfügbar für Verbraucher
+}
+```
+
+**Wenn der Speicher voll ist**:
+- Der Druck steigt von 0,95 auf 1,05 bar
+- Bei 1,05 bar (volle Kapazität) wird überschüssiges Gas abgeblasen
+- Das Abblasen verhindert Überdruck und Schäden an der Ausrüstung
+- In realen Anlagen wird das abgeblasene Gas zur Sicherheitsverbrennung an eine Fackel geleitet
+
+## Konfigurationsexport
+
+Die Anlagenkonfiguration wird im JSON-Format gespeichert:
+
+```json
+{
+  "plant_name": "Quickstart Anlage",
+  "simulation_time": 5.0,
+  "components": [
+    {
+      "component_id": "main_digester",
+      "component_type": "digester",
+      "V_liq": 2000.0,
+      "V_gas": 300.0,
+      "T_ad": 308.15,
+      "state": {...}
+    },
+    {
+      "component_id": "main_digester_storage",
+      "component_type": "storage",
+      "storage_type": "membrane",
+      "capacity_m3": 300.0,
+      "p_min_bar": 0.95,
+      "p_max_bar": 1.05
+    }
+  ],
+  "connections": [
+    {
+      "from": "main_digester",
+      "to": "main_digester_storage",
+      "type": "gas"
+    }
+  ]
+}
+```
+
+Diese JSON-Datei kann neu geladen werden, um den exakten Anlagenzustand wiederherzustellen:
+
+```python
+plant = BiogasPlant.from_json("output/quickstart_config.json", feedstock)
+```
+
+## Nächste Schritte
+
+Nachdem Sie dieses Basisbeispiel ausgeführt haben:
+
+1. **Parameter variieren**:
+   - Passen Sie die Substratzulaufraten in `Q_substrates` an
+   - Ändern Sie die Fermentertemperatur `T_ad`
+   - Ändern Sie das Fermentervolumen `V_liq`
+
+2. **Simulationsdauer verlängern**:
+   ```python
+   results = plant.simulate(duration=30.0, dt=1.0/24.0)
+   ```
+
+3. **Energiekomponenten hinzufügen**:
+   Siehe [`two_stage_plant.md`](two_stage_plant.md) für die Integration von BHKW und Heizung
+
+4. **Steuerung implementieren**:
+   Verwenden Sie `Simulator.determine_best_feed_by_n_sims()` zur Optimierung
+
+## Häufige Probleme
+
+### Problem: "Initialzustandsdatei nicht gefunden"
+
+**Lösung**: Stellen Sie sicher, dass `data/initial_states/digester_initial8.csv` existiert, oder setzen Sie `load_initial_state=False`:
+
+```python
+configurator.add_digester(
+    digester_id="main_digester",
+    V_liq=2000.0,
+    load_initial_state=False,  # Standard-Initialisierung verwenden
+    Q_substrates=Q_substrates,
+)
+```
+
+### Problem: Niedrige Biogasproduktion
+
+**Ursachen**:
+- HRT zu kurz (V_liq erhöhen oder Q_substrates reduzieren)
+- Substratzulauf zu niedrig (Werte in Q_substrates erhöhen)
+- Temperatur zu niedrig (T_ad erhöhen)
+
+**Beispiel-Fix**:
+```python
+Q_substrates = [20, 15, 0, 0, 0, 0, 0, 0, 0, 0]  # Zulauf erhöhen
+```
+
+### Problem: Prozessinstabilität (pH-Abfall)
+
+**Ursachen**:
+- Organische Überlastung (Q_substrates reduzieren)
+- Unzureichende Pufferkapazität
+
+**Beispiel-Fix**:
+```python
+# Puffer-Substrat hinzufügen (z. B. Kalk bei Index 7)
+Q_substrates = [15, 10, 0, 0, 0, 0, 0, 1, 0, 0]  # 1 m³/d Kalk
+```
+
+### Problem: Überdruckwarnungen im Gasspeicher
+
+**Symptome**:
+- Häufige Meldungen über Gasabblasungen
+- Speicher permanent auf maximalem Druck
+
+**Lösungen**:
+```python
+# Gasspeicherkapazität erhöhen
+configurator.add_digester(
+    digester_id="main_digester",
+    V_liq=2000.0,
+    V_gas=500.0,  # Erhöht von 300
+    Q_substrates=Q_substrates,
+)
+```
+
+## Referenzen
+
+- **ADM1-Modell**: Batstone et al. (2002). *Anaerobic Digestion Model No. 1*. IWA Publishing.
+- **PyADM1**: Sadrimajd et al. (2021). *PyADM1: a Python implementation of ADM1*. bioRxiv.
+- **Substratcharakterisierung**: Gaida (2014). *Dynamic real-time substrate feed optimization of anaerobic co-digestion plants*. PhD thesis, Leiden University.
+- **Leitfaden Biogas**: FNR (2016). https://mediathek.fnr.de/leitfaden-biogas.html
+
+## Ähnliche Beispiele
+
+- [`two_stage_plant.md`](two_stage_plant.md): Zweistufige Vergärung mit BHKW und Heizung
+- `calibration_workflow.md`: Parameterschätzung aus Messdaten
+- `substrate_optimization.py`: Optimale Fütterungsstrategie
+- [`parallel_two_stage_simulation.py`](https://github.com/dgaida/PyADM1ODE/blob/master/examples/parallel_two_stage_simulation.py): Parallele Simulationen

--- a/docs/de/examples/parallel_simulation.md
+++ b/docs/de/examples/parallel_simulation.md
@@ -1,1 +1,412 @@
-# Parallel Simulation
+# Beispiel für parallele Simulation
+
+Das Beispiel [examples/05_parallel_two_stage_simulation.py](https://github.com/dgaida/PyADM1ODE/blob/master/examples/05_parallel_two_stage_simulation.py) zeigt die effiziente parallele Ausführung mehrerer Szenarien von Biogasanlagen zur Parameteroptimierung, Sensitivitätsanalyse und Unsicherheitsquantifizierung.
+
+## Übersicht
+
+Dieses Beispiel demonstriert:
+- **Parallele Szenarienausführung**: Gleichzeitiges Ausführen mehrerer Simulationen auf verschiedenen CPU-Kernen.
+- **Parameterstudien (Parameter Sweeps)**: Systematische Untersuchung einzelner und mehrerer Parametervariationen.
+- **Monte-Carlo-Analyse**: Unsicherheitsquantifizierung mit Parameterverteilungen.
+- **Statistische Analyse**: Aggregation von Ergebnissen und vergleichende Statistiken.
+- **Leistungsmetriken**: Messung von Speedup und paralleler Effizienz.
+
+## Architektur
+
+```mermaid
+graph TB
+    subgraph "Hauptprozess"
+        Config[Konfiguration]
+        Results[Ergebnissammlung]
+    end
+
+    subgraph "Worker-Pool (4 Kerne)"
+        W1[Worker 1]
+        W2[Worker 2]
+        W3[Worker 3]
+        W4[Worker 4]
+    end
+
+    Config -->|Szenario 1| W1
+    Config -->|Szenario 2| W2
+    Config -->|Szenario 3| W3
+    Config -->|Szenario 4| W4
+
+    W1 -->|Ergebnis 1| Results
+    W2 -->|Ergebnis 2| Results
+    W3 -->|Ergebnis 3| Results
+    W4 -->|Ergebnis 4| Results
+
+    style Config fill:#e1f5fe
+    style Results fill:#c8e6c9
+    style W1 fill:#fff3e0
+    style W2 fill:#fff3e0
+    style W3 fill:#fff3e0
+    style W4 fill:#fff3e0
+```
+
+## Wichtige Komponenten
+
+### 1. ParallelSimulator
+
+Die Klasse `ParallelSimulator` orchestriert die gleichzeitige Ausführung:
+
+```python
+from pyadm1.simulation.parallel import ParallelSimulator
+
+# Erstellen des parallelen Simulators mit 4 Worker-Prozessen
+parallel = ParallelSimulator(adm1_model, n_workers=4, verbose=True)
+
+# Szenarien definieren
+scenarios = [
+    {"k_dis": 0.5, "Q": [15, 10, 0, 0, 0, 0, 0, 0, 0, 0]},
+    {"k_dis": 0.6, "Q": [20, 10, 0, 0, 0, 0, 0, 0, 0, 0]},
+    {"k_dis": 0.7, "Q": [15, 15, 0, 0, 0, 0, 0, 0, 0, 0]},
+]
+
+# Parallele Simulationen ausführen
+results = parallel.run_scenarios(
+    scenarios=scenarios,
+    duration=10.0,  # 10 Tage
+    initial_state=adm1_state,
+    compute_metrics=True
+)
+```
+
+**Hauptmerkmale**:
+- **Multiprocessing**: Nutzt Pythons `multiprocessing.Pool` für echte Parallelität.
+- **Automatische Lastverteilung**: Szenarien werden gleichmäßig auf die Worker verteilt.
+- **Fortschrittsanzeige**: Echtzeit-Bericht über den Fortschritt bei langlaufenden Analysen.
+- **Fehlerisolierung**: Fehler in einzelnen Szenarien führen nicht zum Abbruch der gesamten Ausführung.
+
+### 2. ScenarioResult
+
+Jede Simulation gibt ein `ScenarioResult`-Objekt zurück:
+
+```python
+@dataclass
+class ScenarioResult:
+    scenario_id: int                          # Eindeutige ID
+    parameters: Dict[str, Any]                # Verwendete Parameterwerte
+    success: bool                             # Abschlussstatus
+    duration: float                           # Simulationsdauer [Tage]
+    final_state: Optional[List[float]]        # Finaler ADM1-Zustandsvektor
+    time_series: Optional[Dict[str, List]]    # Optionale Zeitreihendaten
+    metrics: Dict[str, float]                 # Leistungsmetriken
+    error: Optional[str]                      # Fehlermeldung bei Fehlschlag
+    execution_time: float                     # Reale Laufzeit [Sekunden]
+```
+
+**Berechnete Metriken** (wenn `compute_metrics=True`):
+- `Q_gas`: Gesamtbiogasproduktion [m³/d]
+- `Q_ch4`: Methanproduktion [m³/d]
+- `Q_co2`: CO2-Produktion [m³/d]
+- `CH4_content`: Methananteil [0-1]
+- `pH`: pH-Wert [-]
+- `VFA`: Flüchtige Fettsäuren [g/L]
+- `TAC`: Gesamte Alkalinität [g CaCO3/L]
+- `FOS_TAC`: VFA/TA-Verhältnis [-]
+- `HRT`: Hydraulische Verweilzeit [Tage]
+- `specific_gas_production`: Biogasertrag [m³/m³ Zulauf]
+
+## Simulationstypen
+
+### Einfache parallele Szenarien
+
+Ausführen mehrerer unabhängiger Szenarien mit unterschiedlichen Konfigurationen:
+
+```python
+# Fütterungsszenarien definieren
+feed_scenarios = [
+    {"name": "Niedrige Fütterung", "Q_digester_1": [10, 8, 0, 0, 0, 0, 0, 0, 0, 0]},
+    {"name": "Basis-Fütterung", "Q_digester_1": [15, 10, 0, 0, 0, 0, 0, 0, 0, 0]},
+    {"name": "Hohe Fütterung", "Q_digester_1": [20, 12, 0, 0, 0, 0, 0, 0, 0, 0]},
+]
+
+scenarios = [{"Q": s["Q_digester_1"]} for s in feed_scenarios]
+
+results = parallel.run_scenarios(
+    scenarios=scenarios,
+    duration=10.0,
+    initial_state=adm1_state,
+    dt=1.0/24.0,  # Zeitschritt 1 Stunde
+    compute_metrics=True,
+    save_time_series=False  # Auf True setzen für detaillierte Zeitreihen
+)
+```
+
+**Anwendungsfälle**:
+- Vergleich verschiedener Betriebsstrategien.
+- Testen von Variationen in der Substratzusammensetzung.
+- Bewertung von Designalternativen.
+
+### Einzelparameter-Sweep
+
+Systematische Untersuchung eines Parameters:
+
+```python
+from pyadm1.simulation.parallel import ParameterSweepConfig
+
+# Zerfallsrate (k_dis) untersuchen
+sweep_config = ParameterSweepConfig(
+    parameter_name="k_dis",
+    values=[0.10, 0.14, 0.18, 0.22, 0.26, 0.30],
+    other_params={"Q": [15, 10, 0, 0, 0, 0, 0, 0, 0, 0]}
+)
+
+results = parallel.parameter_sweep(
+    config=sweep_config,
+    duration=10.0,
+    initial_state=adm1_state,
+    compute_metrics=True
+)
+
+# Optimalen Wert finden
+ch4_productions = [r.metrics.get('Q_ch4', 0) for r in results if r.success]
+best_idx = np.argmax(ch4_productions)
+optimal_k_dis = sweep_config.values[best_idx]
+```
+
+**Häufig untersuchte Parameter**:
+- **Kinetische Parameter**: `k_dis`, `k_hyd_ch`, `k_hyd_pr`, `k_hyd_li`
+- **Ertragskoeffizienten**: `Y_su`, `Y_aa`, `Y_fa`, `Y_c4`, `Y_pro`, `Y_ac`, `Y_h2`
+- **Aufnahmeraten**: `k_m_su`, `k_m_aa`, `k_m_fa`, `k_m_c4`, `k_m_pro`, `k_m_ac`
+- **Betriebsparameter**: Fütterungsraten, Temperaturen, Verweilzeiten.
+
+### Multiparameter-Sweep
+
+Vollfaktorielles Design zur Untersuchung von Parameterinteraktionen:
+
+```python
+parameter_configs = {
+    "k_dis": [0.14, 0.18, 0.22],
+    "Y_su": [0.09, 0.10, 0.11],
+    "Q_substrate_0": [12, 15, 18]  # Fütterung Maissilage
+}
+
+results = parallel.multi_parameter_sweep(
+    parameter_configs=parameter_configs,
+    duration=10.0,
+    initial_state=adm1_state,
+    fixed_params={"Q_substrate_1": 10}  # Gülle fixiert auf 10 m³/d
+)
+
+# Gesamtkombinationen: 3 × 3 × 3 = 27 Szenarien
+```
+
+### Monte-Carlo-Simulation
+
+Unsicherheitsquantifizierung mit Parameterverteilungen:
+
+```python
+from pyadm1.simulation.parallel import MonteCarloConfig
+
+mc_config = MonteCarloConfig(
+    n_samples=100,
+    parameter_distributions={
+        "k_dis": (0.18, 0.03),      # Mittelwert=0.18, Std=0.03
+        "Y_su": (0.10, 0.01),       # Mittelwert=0.10, Std=0.01
+        "k_hyd_ch": (10.0, 1.5)     # Mittelwert=10.0, Std=1.5
+    },
+    fixed_params={"Q": [15, 10, 0, 0, 0, 0, 0, 0, 0, 0]},
+    seed=42  # Für Reproduzierbarkeit
+)
+
+results = parallel.monte_carlo(
+    config=mc_config,
+    duration=30.0,
+    initial_state=adm1_state,
+    compute_metrics=True
+)
+
+# Unsicherheit zusammenfassen
+summary = parallel.summarize_results(results)
+
+print(f"Methanproduktion [m³/d]:")
+print(f"  Mittelwert: {summary['metrics']['Q_ch4']['mean']:.1f}")
+print(f"  Std:         {summary['metrics']['Q_ch4']['std']:.1f}")
+print(f"  95% KI:     [{summary['metrics']['Q_ch4']['q25']:.1f}, "
+      f"{summary['metrics']['Q_ch4']['q75']:.1f}]")
+```
+
+## Erwartete Ausgabe
+
+### Vergleich der Basisszenarien
+
+```
+================================================================================
+ERGEBNISSE DES SZENARIENVERGLEICHS
+================================================================================
+
+Niedrige Fütterung:
+  Fütterungsrate: 18.0 m³/d
+  Biogas:         723.5 m³/d
+  Methan:         434.1 m³/d
+  CH4 %:          60.0%
+  pH:             7.28
+  VFA:            1.85 g/L
+  FOS/TAC:        0.228
+  HRT:            109.8 Tage
+  Laufzeit:       2.34 Sekunden
+
+Basis-Fütterung:
+  Fütterungsrate: 25.0 m³/d
+  Biogas:         1005.2 m³/d
+  Methan:         603.1 m³/d
+  CH4 %:          60.0%
+  pH:             7.20
+  VFA:            2.45 g/L
+  FOS/TAC:        0.289
+  HRT:            79.1 Tage
+  Laufzeit:       2.41 Sekunden
+
+Hohe Fütterung:
+  Fütterungsrate: 32.0 m³/d
+  Biogas:         1265.8 m³/d
+  Methan:         759.5 m³/d
+  CH4 %:          60.0%
+  pH:             7.15
+  VFA:            3.12 g/L
+  FOS/TAC:        0.341
+  HRT:            61.8 Tage
+  Laufzeit:       2.38 Sekunden
+```
+
+**Interpretation**:
+- **Die Biogasproduktion skaliert linear** mit der Fütterungsrate (erwartet bei stabilem Betrieb).
+- **Der pH-Wert sinkt** bei höherer Belastung (mehr VFA-Produktion).
+- **FOS/TAC steigt**, bleibt aber unter dem kritischen Schwellenwert (0,4).
+- **Die Laufzeit ist ähnlich** über alle Szenarien (gleiche Rechenkomplexität).
+
+### Parameter-Sweep Ergebnisse
+
+```
+================================================================================
+4. Ausführen des Parameter-Sweeps (Zerfallsrate k_dis)
+================================================================================
+
+   Testen von 6 verschiedenen k_dis-Werten...
+
+   Ergebnisse des Parameter-Sweeps:
+   ------------------------------------------------------------
+      k_dis |      Q_gas |      Q_ch4 |     pH |      VFA
+   ------------------------------------------------------------
+       0.10 |      865.3 |      519.2 |   7.35 |     1.52
+       0.14 |      925.8 |      555.5 |   7.28 |     1.85
+       0.18 |      982.4 |      589.4 |   7.22 |     2.18
+       0.22 |     1005.2 |      603.1 |   7.20 |     2.45
+       0.26 |     1015.6 |      609.4 |   7.18 |     2.68
+       0.30 |     1018.2 |      610.9 |   7.17 |     2.85
+
+   ✓ Optimales k_dis = 0.30 (CH4 = 610.9 m³/d)
+```
+
+**Beobachtungen**:
+- **Die Methanproduktion steigt** mit k_dis (schnellerer Zerfall).
+- **Abnehmender Grenznutzen** oberhalb von k_dis = 0,26 (nur 1,5 m³/d Steigerung).
+- **Der pH-Wert sinkt leicht** aufgrund der schnelleren Produktion organischer Säuren.
+- **Zielkonflikt**: Höheres k_dis → mehr Gas, aber geringere pH-Stabilität.
+
+### Monte-Carlo-Statistiken
+
+```
+================================================================================
+6. Ausführen der Monte-Carlo-Unsicherheitsanalyse
+================================================================================
+
+   Ausführen von 50 Monte-Carlo-Stichproben...
+
+   Zusammenfassende Monte-Carlo-Statistiken:
+   ------------------------------------------------------------
+
+   Q_gas:
+      Mittelwert: 1002.45
+      Std:          58.32
+      Min:         885.20
+      Max:        1125.80
+      Median:      998.60
+      Q25:         965.15
+      Q75:        1038.22
+
+   Q_ch4:
+      Mittelwert:  601.47
+      Std:          35.00
+      Min:         531.12
+      Max:         675.48
+      Median:      599.16
+      Q25:         579.09
+      Q75:         622.93
+
+   pH:
+      Mittelwert:    7.21
+      Std:           0.08
+      Min:           7.05
+      Max:           7.38
+      Median:        7.20
+      Q25:           7.15
+      Q75:           7.26
+
+   Erfolgsquote: 100.0%
+```
+
+## Performance-Analyse
+
+### Parallele Effizienz
+
+```
+================================================================================
+ZUSAMMENFASSUNG DER SIMULATION
+================================================================================
+
+Gesamtlaufzeit: 125.3 Sekunden
+Durchschnittliche Zeit pro Simulation: 1.05 Sekunden
+
+Parallele Effizienz:
+  Verwendete Worker: 4
+  Theoretische sequentielle Zeit: 475.8 Sekunden
+  Speedup: 3.80x
+  Parallele Effizienz: 95.0%
+```
+
+**Leistungsmetriken**:
+- **Speedup**: 475,8 / 125,3 = 3,80×
+- **Effizienz**: 3,80 / 4 = 95,0 %
+- **Overhead**: 5 % aufgrund von:
+  - Prozesserstellung/-abbau.
+  - Datenserialisierung/-deserialisierung.
+  - Ergebnistransfer.
+
+## Best Practices
+
+### 1. Wahl der Anzahl der Worker
+
+```python
+import multiprocessing as mp
+
+# Faustregel: n_workers = CPU_count - 1
+optimal_workers = max(1, mp.cpu_count() - 1)
+
+parallel = ParallelSimulator(adm1, n_workers=optimal_workers)
+```
+
+### 2. Balance zwischen Simulationsdauer und Anzahl der Szenarien
+
+- Kurze Simulationen (< 1 Sekunde): Overhead dominiert → Dauer erhöhen oder sequentiell ausführen.
+- Mittlere Simulationen (1-10 Sekunden): Gute Parallelisierung → Ideal für Parameterstudien.
+- Lange Simulationen (> 60 Sekunden): Speicherintensiv → Anzahl der Worker reduzieren oder Batching verwenden.
+
+## Ähnliche Beispiele
+
+- [`basic_digester.md`](basic_digester.md): Grundlagen der Fermentersimulation.
+- [`two_stage_plant.md`](two_stage_plant.md): Konfiguration zweistufiger Anlagen.
+- `calibration_workflow.md`: Parameterkalibrierung mittels paralleler Optimierung.
+
+## Zusammenfassung
+
+Das Beispiel für parallele Simulation zeigt:
+
+1. **Effiziente Parameterexploration**: Testen mehrerer Szenarien 3-4× schneller durch parallele Ausführung.
+2. **Systematische Optimierung**: Parameter-Sweeps identifizieren optimale Betriebsbedingungen.
+3. **Unsicherheitsquantifizierung**: Die Monte-Carlo-Analyse quantifiziert die Vorhersageunsicherheit.
+4. **Skalierbare Architektur**: Handhabung von Hunderten von Szenarien mit ordnungsgemäßem Batching und Fehlerbehandlung.
+5. **Statistische Analyse**: Umfassende Ergebniszusammenfassung und vergleichende Statistiken.

--- a/docs/de/examples/two_stage_plant.md
+++ b/docs/de/examples/two_stage_plant.md
@@ -1,1 +1,728 @@
-# Beispiele
+# Zweistufige Biogasanlage Beispiel
+
+Das Beispiel [examples/02_two_stage_plant.py](https://github.com/dgaida/PyADM1ODE/blob/master/examples/02_two_stage_plant.py) zeigt eine komplette zweistufige Biogasanlage mit mechanischen Komponenten, Energieintegration und umfassender Prozessüberwachung.
+
+## Anlagenschema
+
+![Anlagenschema](two_stage_plant_schematic.png)
+
+## Systemarchitektur
+
+```mermaid
+graph TB
+    %% Substratzulauf
+    Feed[Substratzulauf<br/>Maissilage: 15 m³/d<br/>Rindergülle: 10 m³/d]
+
+    %% Fütterungspumpe
+    Feed -->|25 m³/d| FeedPump[Fütterungspumpe<br/>Exzenterschneckenpumpe<br/>30 m³/h Kapazität]
+
+    %% Erste Stufe - Hydrolyse
+    FeedPump --> Dig1[Fermenter 1 - Hydrolyse<br/>V_liq: 1977 m³, V_gas: 304 m³<br/>T: 45°C thermophil<br/>Verbesserte Hydrolyse]
+
+    %% Rührwerk 1
+    Mixer1[Rührwerk 1<br/>Propeller, 15 kW<br/>Hohe Intensität<br/>25% Einschaltdauer] -.->|Rühren| Dig1
+
+    %% Gasspeicher 1
+    Dig1 -->|Biogas ~850 m³/d| Storage1[Gasspeicher 1<br/>Membran<br/>304 m³ Kapazität]
+
+    %% Heizung 1
+    Heating1[Heizsystem 1<br/>Soll: 45°C<br/>Wärmeverlust: 0.5 kW/K] -.->|Wärme| Dig1
+
+    %% Transferpumpe
+    Dig1 -->|Ablauf 25 m³/d| TransPump[Transferpumpe<br/>Exzenterschneckenpumpe<br/>25 m³/h Kapazität]
+
+    %% Zweite Stufe - Methanogenese
+    TransPump --> Dig2[Fermenter 2 - Methanogenese<br/>V_liq: 1000 m³, V_gas: 150 m³<br/>T: 35°C mesophil<br/>Stabile CH₄-Produktion]
+
+    %% Rührwerk 2
+    Mixer2[Rührwerk 2<br/>Propeller, 10 kW<br/>Mittlere Intensität<br/>25% Einschaltdauer] -.->|Rühren| Dig2
+
+    %% Gasspeicher 2
+    Dig2 -->|Biogas ~400 m³/d| Storage2[Gasspeicher 2<br/>Membran<br/>150 m³ Kapazität]
+
+    %% Heizung 2
+    Heating2[Heizsystem 2<br/>Soll: 35°C<br/>Wärmeverlust: 0.3 kW/K] -.->|Wärme| Dig2
+
+    %% Kombinierter Gasfluss zum BHKW
+    Storage1 -->|Gasversorgung| CHP[BHKW-Einheit<br/>500 kWe nominal<br/>ηe: 40%, ηth: 45%<br/>Gesamt: ~1250 m³/d]
+    Storage2 -->|Gasversorgung| CHP
+
+    %% BHKW-Ausgänge
+    CHP -->|Elektrisch| Power[Stromausgang<br/>~480 kWe]
+    CHP -->|Thermisch ~540 kW| HeatDist[Wärmeverteilung]
+    CHP -->|Überschüssiges Gas| Flare[Fackel<br/>Sicherheitsverbrennung<br/>98% Zerstörung]
+
+    %% Wärmeverteilung
+    HeatDist -->|Wärmeversorgung| Heating1
+    HeatDist -->|Wärmeversorgung| Heating2
+
+    %% Finale Ausgänge
+    Dig2 -->|Gärrest<br/>25 m³/d| Effluent[Gärrestaustrag]
+
+    %% Styling
+    classDef processBox fill:#e1f5fe,stroke:#01579b,stroke-width:3px
+    classDef storageBox fill:#fff3e0,stroke:#e65100,stroke-width:2px
+    classDef mechanicalBox fill:#f3e5f5,stroke:#4a148c,stroke-width:2px
+    classDef energyBox fill:#e8f5e9,stroke:#1b5e20,stroke-width:3px
+    classDef inputBox fill:#f1f8e9,stroke:#33691e,stroke-width:2px
+    classDef outputBox fill:#fce4ec,stroke:#880e4f,stroke-width:2px
+
+    class Dig1,Dig2 processBox
+    class Storage1,Storage2 storageBox
+    class FeedPump,TransPump,Mixer1,Mixer2 mechanicalBox
+    class CHP,Heating1,Heating2,HeatDist,Flare energyBox
+    class Feed inputBox
+    class Power,Effluent outputBox
+```
+
+## Übersicht
+
+Die zweistufige Anlage demonstriert:
+- **Temperature-Phased Anaerobic Digestion (TPAD)**: Thermophile Hydrolyse (45°C) gefolgt von mesophiler Methanogenese (35°C)
+- **Mechanische Komponenten**: Pumpen für den Materialtransport und Rührwerke zur Prozessunterstützung
+- **Energieintegration**: BHKW zur Stromerzeugung und Abwärmenutzung
+- **Prozesssteuerung**: Mehrere Heizsysteme für ein präzises Temperaturmanagement
+- **Gasmanagement**: Dedizierter Speicher für jeden Fermenter mit automatischem Überlaufschutz und zentraler Fackel
+
+## Anlagenkonfiguration
+
+### Biologische Komponenten
+
+| Komponente | Volumen | Temperatur | Funktion | HRT |
+|------------|---------|------------|----------|-----|
+| **Fermenter 1** | 1977 m³ liq + 304 m³ gas | 45°C (thermophil) | Hydrolyse komplexer Organik | 79 Tage |
+| **Fermenter 2** | 1000 m³ liq + 150 m³ gas | 35°C (mesophil) | Methanogenese (CH₄-Produktion) | 40 Tage |
+| **Gesamt** | 2977 m³ | - | - | 119 Tage |
+
+**Gesamte organische Raumbelastung (OLR)**: 25 m³/d ÷ 2977 m³ ≈ **0,0084 d⁻¹** oder **8,4 kg CSB/(m³·d)**
+
+### Mechanische Komponenten
+
+| Komponente | Typ | Kapazität | Leistung | Funktion |
+|------------|-----|-----------|----------|----------|
+| **Fütterungspumpe** | Exzenterschnecke | 30 m³/h | ~5 kW | Substratfütterung in Fermenter 1 |
+| **Transferpumpe** | Exzenterschnecke | 25 m³/h | ~8 kW | Ablauf-Transfer: F1 → F2 |
+| **Rührwerk 1** | Propeller | 15 kW | 15 kW | Hochintensive Durchmischung für Hydrolyse |
+| **Rührwerk 2** | Propeller | 10 kW | 10 kW | Mittlere Durchmischung für Methanogenese |
+
+**Gesamter Eigenverbrauch**: ~20 kW (Rührwerke laufen mit 25 % Einschaltdauer)
+
+### Energiekomponenten
+
+| Komponente | Spezifikation | Wirkungsgrad | Leistung |
+|------------|---------------|--------------|----------|
+| **BHKW-Einheit** | 500 kW$ nominal | η$ = 40 %, ηcat{th}$ = 45 % | 500 kW$ + 562 kWcat{th}$ |
+| **Heizung 1** | Fermenter 1 Heizung | - | Hält 45°C |
+| **Heizung 2** | Fermenter 2 Heizung | - | Hält 35°C |
+| **Fackel** | Sicherheitsverbrennung | 98 % Zerstörung | Entsorgung von Überschussgas |
+
+### Gasmanagement-System
+
+| Komponente | Typ | Kapazität | Funktion |
+|------------|-----|-----------|----------|
+| **Speicher 1** | Membran | 304 m³ | Puffer für Gas aus Fermenter 1 |
+| **Speicher 2** | Membran | 150 m³ | Puffer für Gas aus Fermenter 2 |
+| **BHKW-Fackel** | Verbrennung | Variabel | Sicherheitsentsorgung von Überschussgas |
+
+**Gasfluss-Architektur**:
+1. Jeder Fermenter produziert Gas → Dedizierter Speicher
+2. Beide Speicher liefern Gas → Einzelne BHKW-Einheit
+3. BHKW-Überschuss/Überlauf → Automatische Fackelverbrennung
+
+## Code-Durchgang
+
+### 1. Erweiterte Imports
+
+```python
+from pyadm1.components.mechanical.mixer import Mixer
+from pyadm1.components.mechanical.pump import Pump
+```
+
+Diese importieren die mechanischen Komponenten, die im Basisbeispiel nicht verwendet wurden.
+
+### 2. Zweistufige Fermenter-Konfiguration
+
+```python
+# Fermenter 1: Thermophile Hydrolyse
+configurator.add_digester(
+    digester_id="digester_1",
+    V_liq=1977.0,
+    V_gas=304.0,
+    T_ad=318.15,  # 45°C für verbesserte Hydrolyse
+    Q_substrates=[15, 10, 0, 0, 0, 0, 0, 0, 0, 0],
+)
+
+# Fermenter 2: Mesophile Methanogenese
+configurator.add_digester(
+    digester_id="digester_2",
+    V_liq=1000.0,
+    V_gas=150.0,
+    T_ad=308.15,  # 35°C optimal für Methanogene
+    Q_substrates=[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],  # Empfängt nur Ablauf
+)
+```
+
+**Design-Überlegungen**:
+- **Stufe 1 (thermophil)**: Höhere Temperaturen verbessern die Hydrolyse komplexer Substrate (Zellulose, Hemizellulose, Proteine).
+- **Stufe 2 (mesophil)**: Niedrigere Temperaturen sind stabiler und effizienter für die Methanogenese.
+- **Nur Ablauf-Fütterung für Stufe 2**: Verhindert Überlastung, erhält vorhydrolysiertes Material.
+
+**Automatische Gasspeicher-Erstellung**:
+- `add_digester()` erstellt automatisch:
+  - `digester_1_storage` (304 m³ Membranspeicher)
+  - `digester_2_storage` (150 m³ Membranspeicher)
+- Die Speicher werden automatisch mit ihren Fermentern verbunden.
+
+### 3. Mechanische Komponenten hinzufügen
+
+#### Fütterungspumpe
+```python
+feed_pump = Pump(
+    component_id="feed_pump",
+    pump_type="progressive_cavity",  # Handhabt dicke Suspensionen
+    Q_nom=30.0,  # m³/h nominal
+    pressure_head=5.0,  # Niedriger Druck
+)
+```
+
+**Exzenterschneckenpumpen** sind ideal für Biogassubstrate, weil sie:
+- Hohe Feststoffgehalte (>12 % TS) bewältigen
+- Scherkräfte minimieren (Faserstruktur bleibt erhalten)
+- Selbstansaugend sind
+- Einen weiten Viskositätsbereich abdecken
+
+#### Transferpumpe
+```python
+transfer_pump = Pump(
+    component_id="transfer_pump",
+    pump_type="progressive_cavity",
+    Q_nom=25.0,  # m³/h
+    pressure_head=8.0,  # Höherer Druck für Transfer zwischen Fermentern
+)
+```
+
+Höherer Druck erforderlich für:
+- Überwindung von Rohrreibungslasten
+- Höhenunterschiede
+- Injektion in unter Druck stehenden Fermenter
+
+#### Rührwerke
+```python
+mixer_1 = Mixer(
+    component_id="mixer_1",
+    mixer_type="propeller",
+    tank_volume=1977.0,
+    mixing_intensity="high",  # Aggressiv für Hydrolyse
+    power_installed=15.0,
+    intermittent=True,
+    on_time_fraction=0.25,  # 6 Stunden an, 18 Stunden aus
+)
+```
+
+**Rührstrategie**:
+- **Intermittierender Betrieb**: Reduziert den Energieverbrauch um 75 %.
+- **Hohe Intensität in der Hydrolyse**: Aufbrechen von Schwimmschichten, verbessert den Substratkontakt.
+- **Mittlere Intensität in der Methanogenese**: Schonendes Rühren verhindert die Hemmung empfindlicher Methanogener.
+
+**Spezifischer Leistungseintrag**:
+- Fermenter 1: 15 kW × 0,25 ÷ 1977 m³ = **1,9 W/m³** (hoch)
+- Fermenter 2: 10 kW × 0,25 ÷ 1000 m³ = **2,5 W/m³** (mittel)
+
+### 4. Energieintegration mit automatischer Fackel
+
+```python
+# BHKW hinzufügen (erstellt automatisch Fackel)
+configurator.add_chp(
+    chp_id="chp_1",
+    P_el_nom=500.0,
+    eta_el=0.40,
+    eta_th=0.45,
+    name="Haupt-BHKW",
+)
+
+# Automatische Verbindungen handhaben das Gas-Routing
+configurator.auto_connect_digester_to_chp("digester_1", "chp_1")
+configurator.auto_connect_digester_to_chp("digester_2", "chp_1")
+
+# Wärmerückgewinnung für beide Fermenter
+configurator.auto_connect_chp_to_heating("chp_1", "heating_1")
+configurator.auto_connect_chp_to_heating("chp_1", "heating_2")
+```
+
+**Verbindungskette**:
+```
+Fermenter 1 → Speicher 1 ↘
+                          → BHKW → Fackel (automatisch)
+Fermenter 2 → Speicher 2 ↗      ↓
+                          Wärme → Heizung 1 & 2
+```
+
+**Automatische Fackelerstellung**:
+- `add_chp()` erstellt automatisch eine Fackelkomponente.
+- Fackel-ID: `{chp_id}_flare` (z. B. "chp_1_flare")
+- Funktion: Sicherheitsverbrennung von Überschussgas (98 % CH₄-Zerstörung)
+- Automatische Verbindung: BHKW → Fackel
+
+### 5. Drei-Pass-Gasfluss-Simulation
+
+Die Simulation erfolgt in drei Durchgängen für ein realistisches Gasmanagement:
+
+**Pass 1 - Gasproduktion**:
+```python
+# Fermenter produzieren Gas → Speichertanks
+Fermenter 1: Q_gas = 850 m³/d → Speicher 1
+Fermenter 2: Q_gas = 400 m³/d → Speicher 2
+```
+
+**Pass 2 - Speicher-Aktualisierung**:
+```python
+# Speicher empfangen Gas, aktualisieren Druck und Volumen
+Speicher 1: gespeichertes_volumen += 850 * dt
+Speicher 2: gespeichertes_volumen += 400 * dt
+# Wenn voll: Überschuss an die Atmosphäre ablassen
+```
+
+**Pass 3 - Gasverbrauch**:
+```python
+# BHKW fordert Gas von den Speichern an
+BHKW-Bedarf: 1150 m³/d Biogas
+Speicher 1 liefert: ~675 m³/d
+Speicher 2 liefert: ~475 m³/d
+# BHKW arbeitet mit tatsächlichem Angebot
+# Überschuss zur Fackel: (Angebot - Verbrauch)
+```
+
+Dies gewährleistet:
+- Realistisches Druckmanagement in Speichern
+- BHKW arbeitet mit verfügbarem Gas, nicht mit idealisiertem Angebot
+- Automatisches Abblasen verhindert Überdruck
+- Die Fackel handhabt das gesamte Überschussgas sicher
+
+## Erwartete Ausgabe
+
+### Anlagenzusammenfassung
+```
+=== Zweistufige Anlage mit mechanischen Komponenten ===
+Simulationszeit: 0.00 Tage
+
+Komponenten (12):
+  - Hydrolyse-Fermenter (digester)
+  - Hydrolyse-Fermenter Gasspeicher (storage)
+  - Methanogenese-Fermenter (digester)
+  - Methanogenese-Fermenter Gasspeicher (storage)
+  - Substratfütterungspumpe (pump)
+  - Fermenter Transferpumpe (pump)
+  - Hydrolyse-Rührwerk (mixer)
+  - Methanogenese-Rührwerk (mixer)
+  - Haupt-BHKW (chp)
+  - Haupt-BHKW Fackel (flare)
+  - Hydrolyse-Heizung (heating)
+  - Methanogenese-Heizung (heating)
+
+Verbindungen (10):
+  - Hydrolyse-Fermenter -> Methanogenese-Fermenter (liquid)
+  - Hydrolyse-Fermenter Gasspeicher -> Haupt-BHKW (gas)
+  - Methanogenese-Fermenter Gasspeicher -> Haupt-BHKW (gas)
+  - Haupt-BHKW -> Haupt-BHKW Fackel (gas)
+  - Haupt-BHKW -> Hydrolyse-Heizung (heat)
+  - Haupt-BHKW -> Methanogenese-Heizung (heat)
+```
+
+### Finale Ergebnisse (Tag 10)
+
+```
+ERGEBNISANALYSE
+======================================================================
+
+Finaler Zustand (Tag 10.0):
+----------------------------------------------------------------------
+
+Hydrolyse-Fermenter:
+  Biogasproduktion:        850.3 m³/d
+  Methanproduktion:       493.2 m³/d
+  pH:                         7.15
+  VFA:                        3.82 g/L
+  Temperatur:               45.0 °C
+  Gasspeicher:
+    - Gespeichertes Volumen:  152.1 m³ (50%)
+    - Druck:               1.00 bar
+    - Abgeblasen:                  0.0 m³
+
+Methanogenese-Fermenter:
+  Biogasproduktion:        402.8 m³/d
+  Methanproduktion:       258.7 m³/d
+  pH:                         7.32
+  VFA:                        1.95 g/L
+  Temperatur:               35.0 °C
+  Gasspeicher:
+    - Gespeichertes Volumen:   75.0 m³ (50%)
+    - Druck:               1.00 bar
+    - Abgeblasen:                  0.0 m³
+
+Gesamtproduktion der Anlage:
+  Gesamtbiogas:            1253.1 m³/d
+  Gesamtmethan:            751.9 m³/d
+  Methangehalt:           60.0 %
+
+BHKW-Leistung:
+  Elektrische Leistung:     480.5 kW
+  Thermische Leistung:      540.6 kW
+  Gasverbrauch:            1150.0 m³/d
+  Gas aus Speicher 1:       675.2 m³/d
+  Gas aus Speicher 2:       474.8 m³/d
+  Überschuss zur Fackel:    103.1 m³/d
+  Betriebsstunden:          240.0 h
+
+Fackel-Leistung:
+  Gas erhalten:             103.1 m³/d
+  CH₄ zerstört:             60.6 m³/d (98% Effizienz)
+  Kumulativ abgeblasen:    1031.0 m³
+
+Hydrolyse-Rührwerk:
+  Leistungsaufnahme:          3.75 kW
+  Mischqualität:             0.92
+  Reynolds-Zahl:         12500
+
+Methanogenese-Rührwerk:
+  Leistungsaufnahme:          2.50 kW
+  Mischqualität:             0.88
+  Reynolds-Zahl:          8300
+```
+
+### Energiebilanz
+
+```
+ENERGIEBILANZ
+======================================================================
+
+Energieproduktion:
+  Elektrisch (brutto):      480.5 kW
+  Thermisch:                 540.6 kW
+
+Eigenverbrauch:
+  Rührwerk 1:                 3.75 kW
+  Rührwerk 2:                 2.50 kW
+  Pumpen (geschätzt):          2.00 kW
+  Gesamter Eigenverbrauch:    8.25 kW
+
+Netto-Elektrizitätsleistung: 472.3 kW
+
+Wärmenutzung:
+  Heizbedarf:               125.4 kW
+  BHKW-Wärmeangebot:        540.6 kW
+  Wärmeabdeckung:           431.0 %
+
+Gasmanagement:
+  Gesamtproduktion:        1253.1 m³/d
+  BHKW-Verbrauch:          1150.0 m³/d
+  Zur Fackel:               103.1 m³/d (8.2%)
+```
+
+**Analyse**:
+- **Netto-Wirkungsgrad**: (472 kW + 125 kW) ÷ (751,9 m³/d × 10 kWh/m³ ÷ 24 h) = **190 %** (exzellente Wärmerückgewinnung)
+- **Eigenverbrauchsquote**: 8,25 ÷ 480,5 = **1,7 %** (sehr niedrig)
+- **Überschusswärme**: 540,6 - 125,4 = **415 kW** für externe Nutzung verfügbar
+- **Fackelnutzung**: 8,2 % der Produktion abgeblasen (typisch bei BHKW-Teillast)
+
+### Prozessstabilität
+
+```
+BEWERTUNG DER PROZESSSTABILITÄT
+======================================================================
+
+Fermenter 1 (Hydrolyse):
+  pH-Stabilität:        PRÜFEN (7.15 - etwas niedrig)
+  VFA-Level:            HOCH (3.82 g/L)
+  FOS/TAC-Verhältnis:   0.418 (Beobachten)
+  Speicherstatus:       NORMAL (50% voll)
+
+Fermenter 2 (Methanogenese):
+  pH-Stabilität:        GUT (7.32)
+  VFA-Level:            GUT (1.95 g/L)
+  FOS/TAC-Verhältnis:   0.245 (Stabil)
+  Speicherstatus:       NORMAL (50% voll)
+```
+
+**Interpretation**:
+- **Fermenter 1**: Höhere VFA-Werte werden in der thermophilen Hydrolysestufe erwartet - Säuren werden in Stufe 2 verbraucht.
+- **Fermenter 2**: Exzellente Stabilitätsindikatoren - Methanogene verbrauchen VFAs effektiv.
+- **pH-Gradient**: 7,15 → 7,32 zeigt ordnungsgemäße zweistufige Funktion.
+- **Gasspeicher**: Beide auf gesundem 50 % Füllstand mit stabilem Druck.
+
+## Vorteile des zweistufigen Designs
+
+### 1. Prozessoptimierung
+
+| Aspekt | Einstufig | Zweistufig |
+|--------|-----------|------------|
+| **Hydrolyse** | Begrenzt durch mesophile Temp | Verbessert bei 45°C |
+| **Methanogenese** | Muss VFA-Spitzen tolerieren | Stabile, gepufferte Fütterung |
+| **OLR-Kapazität** | 3-4 kg CSB/(m³·d) | 5-8 kg CSB/(m³·d) |
+| **Prozessstabilität** | Moderat | Hoch |
+
+### 2. Substratflexibilität
+
+Das zweistufige System kommt besser mit schwierigen Substraten zurecht:
+- **Faserreiche Materialien**: Verbesserte Hydrolyse in Stufe 1.
+- **Proteinreiche Substrate**: Ammoniakpufferung über die Stufen hinweg.
+- **Variable Zulaufzusammensetzung**: Stufe 2 bietet Pufferkapazität.
+
+### 3. Operative Vorteile
+
+- **Reduzierte Schaumbildung**: Separate Hydrolysephase.
+- **Bessere Hygienisierung**: Thermophile Stufe (45°C) tötet Pathogene ab.
+- **Einfachere Prozesssteuerung**: Überwachung und Steuerung jeder Stufe unabhängig voneinander.
+- **Erholung von Störungen**: Stufe 2 kann Störungen in Stufe 1 abpuffern.
+
+## Leistungsvergleich
+
+### Einstufig vs. Zweistufig
+
+| Metrik | Einstufig (2000 m³ @ 35°C) | Zweistufig (1977+1000 m³) | Verbesserung |
+|--------|-----------------------------|---------------------------|--------------|
+| **Biogasertrag** | 1150 m³/d | 1253 m³/d | +9 % |
+| **CH₄-Gehalt** | 58 % | 60 % | +3,4 % |
+| **Spezifischer Ertrag** | 46 m³/m³ Zulauf | 50 m³/m³ Zulauf | +8,7 % |
+| **Prozessstabilität** | Moderat (FOS/TAC: 0,35) | Hoch (FOS/TAC: 0,25) | Besser |
+| **OLR-Kapazität** | 3,5 kg CSB/(m³·d) | 8,4 kg CSB/(m³·d) | +140 % |
+
+**Kosten-Nutzen**:
+- **Zusatzinvestition**: ~15-20 % (zweiter Fermenter, Pumpen)
+- **Energiegewinn**: ~9 % mehr Biogas
+- **Stabilität**: Signifikant reduziertes Risiko von Prozessversagen
+- **ROI**: Typischerweise 3-5 Jahre bei schwierigen Substraten
+
+## Leistung mechanischer Komponenten
+
+### Pumpenbetrieb
+
+**Fütterungspumpe**:
+- **Betriebspunkt**: 25 m³/d ÷ 24 = 1,04 m³/h (3,5 % der Nennkapazität)
+- **Effizienz bei niedrigem Durchfluss**: Exzenterschneckenpumpen behalten ca. 60 % Wirkungsgrad auch bei 3 % Kapazität bei.
+- **Jährliche Energie**: 5 kW × 8760 h = 43.800 kWh
+
+**Transferpumpe**:
+- **Betriebspunkt**: 25 m³/d ÷ 24 = 1,04 m³/h
+- **Tatsächliche Leistung**: 8 kW × (1,04/25) × 1,2 (Abschlag für niedrige Effizienz) ≈ **0,4 kW**
+- **Jährliche Energie**: 0,4 kW × 8760 h = 3.504 kWh
+
+### Rührwerksleistung
+
+**Hydrolyse-Rührwerk**:
+- **Mischzeit**: ~15 Minuten (aus Reynolds-Zahl und Geometrie)
+- **Umfangsgeschwindigkeit**: ~4,5 m/s (turbulenter Bereich)
+- **Scherrate**: ~50 s⁻¹ (hohe Intensität)
+- **Leistungsbeiwert**: 0,32 (typisch für Propeller bei Re > 10.000)
+
+**Methanogenese-Rührwerk**:
+- **Mischzeit**: ~20 Minuten
+- **Umfangsgeschwindigkeit**: ~3,8 m/s
+- **Scherrate**: ~35 s⁻¹ (mittlere Intensität)
+- **Verhindert Entmischung**, ohne empfindliche Methanogene zu schädigen.
+
+## Gasspeicher- und Fackelmanagement
+
+### Speicherdynamik
+
+**Speicher 1 (Hydrolyse)**:
+- Erhält ~850 m³/d (höhere Produktion durch verbesserte Hydrolyse).
+- Liefert ~675 m³/d an BHKW (proportional zum Gesamtbedarf).
+- Netto-Akkumulation: +175 m³/d.
+- Erreicht 50 % Kapazität in ~0,9 Tagen.
+
+**Speicher 2 (Methanogenese)**:
+- Erhält ~400 m³/d (niedriger, aber stabiler).
+- Liefert ~475 m³/d an BHKW.
+- Netto-Abzug: -75 m³/d (ergänzt Speicher 1).
+- Bietet Puffer für Produktionsschwankungen.
+
+### Fackelbetrieb
+
+**Wann wird die Fackel aktiviert?**:
+1. **Speicherüberlauf**: Wenn einer der Speicher 100 % Kapazität erreicht.
+2. **BHKW-Teillast**: Wenn das BHKW unter Volllast arbeitet.
+3. **Wartung**: Wenn das BHKW offline ist, die Fermenter aber weiterlaufen.
+4. **Anfahren/Abfahren**: Während transienter Betriebszustände.
+
+**Fackelleistung**:
+- **Zerstörungsgrad**: 98 % CH₄-Konvertierung zu CO₂.
+- **Temperatur**: ~1000°C Verbrennungstemperatur.
+- **Emissionen**: 2 % unverbranntes CH₄ + CO₂ aus der Verbrennung.
+- **Sicherheit**: Automatische Zündung, Flammenüberwachung.
+
+## Prozesssteuerungsstrategien
+
+### Temperatursteuerung
+
+```python
+# Heizung 1 hält 45°C für Hydrolyse
+heating_1.target_temperature = 318.15  # K
+heating_1.heat_loss_coefficient = 0.5  # Höher aufgrund von ΔT
+
+# Heizung 2 hält 35°C für Methanogenese
+heating_2.target_temperature = 308.15  # K
+heating_2.heat_loss_coefficient = 0.3  # Niedrigeres ΔT
+```
+
+**Berechnung des Wärmebedarfs**:
+- **Fermenter 1**: Q = 0,5 kW/K × (45 - 15)°C = **15 kW** Basisverlust + **80 kW** Prozessheizung = **95 kW**
+- **Fermenter 2**: Q = 0,3 kW/K × (35 - 15)°C = **6 kW** Basisverlust + **24 kW** Prozessheizung = **30 kW**
+- **Gesamt**: **125 kW** (gut abgedeckt durch 541 kW BHKW-Wärmeleistung)
+
+### Rührwerkssteuerung
+
+**Strategie**: Intermittierendes Rühren mit adaptiver Zeitsteuerung
+```python
+# Hohe Durchmischung bei Fütterung (4× täglich)
+if feeding_event:
+    mixer.on_time_fraction = 0.5  # 50% Einschaltdauer
+else:
+    mixer.on_time_fraction = 0.15  # 15% Basislinie
+```
+
+### Fütterungssteuerung
+
+**Model Predictive Control (MPC)** Ansatz:
+1. Messen der aktuellen VFA und des pH-Werts.
+2. Vorhersagen der 48h-Reaktion mit verschiedenen Fütterungsraten.
+3. Auswählen der Fütterungsrate, die CH₄ optimiert, während pH > 7,0 bleibt.
+
+## Häufige Probleme und Lösungen
+
+### Problem 1: Hohe VFA in Fermenter 1
+
+**Symptome**:
+- VFA > 5 g/L
+- pH < 7,0
+- Reduzierte Gasproduktion
+
+**Lösungen**:
+```python
+# Organische Belastung reduzieren
+Q_substrates = [12, 8, 0, 0, 0, 0, 0, 0, 0, 0]  # Reduzieren von [15, 10, ...]
+
+# Temperatur in Stufe 1 erhöhen (Vorsicht - max. 55°C)
+T_ad_1 = 323.15  # 50°C
+
+# Rühren verstärken, um Akkumulation zu verhindern
+mixer_1.on_time_fraction = 0.35
+```
+
+### Problem 2: Niedriger Methangehalt
+
+**Symptome**:
+- CH₄ < 55 %
+- CO₂ erhöht
+- Niedrige spezifische Gasproduktion
+
+**Lösungen**:
+```python
+# HRT erhöhen (Fütterung reduzieren)
+Q_substrates = [12, 8, 0, 0, 0, 0, 0, 0, 0, 0]
+
+# Temperatur in Stufe 2 optimieren
+T_ad_2 = 311.15  # 38°C (optimal für viele Methanogene)
+
+# Auf Lufteintritt prüfen (O₂ hemmt Methanogene)
+```
+
+### Problem 3: Schaumbildung in Fermenter 1
+
+**Symptome**:
+- Gasspeicher zeigt Druckschwankungen
+- Ablauf enthält übermäßige Gasblasen
+
+**Lösungen**:
+```python
+# Rührintensität reduzieren
+mixer_1.mixing_intensity = "medium"
+
+# Antischaummittel hinzufügen (Substrat-Index 8)
+Q_substrates = [15, 10, 0, 0, 0, 0, 0, 0, 0.05, 0]  # 50 L/d Antischaum
+
+# Transferrate zu Stufe 2 erhöhen
+# (implementieren eines Timer-basierten periodischen Abzugs)
+```
+
+### Problem 4: Übermäßige Fackelnutzung
+
+**Symptome**:
+- Fackel läuft kontinuierlich
+- >20 % der Produktion zur Fackel
+- Hoher Speicherdruck
+
+**Ursachen**:
+- BHKW zu klein für Gasproduktion
+- BHKW im Teillastbetrieb
+- Übermäßiger Substratzulauf
+
+**Lösungen**:
+```python
+# Option 1: Substratzulauf reduzieren
+Q_substrates = [12, 8, 0, 0, 0, 0, 0, 0, 0, 0]
+
+# Option 2: BHKW-Kapazität erhöhen
+configurator.add_chp("chp1", P_el_nom=600, ...)  # Erhöhen von 500
+
+# Option 3: Zweite BHKW-Einheit hinzufügen
+configurator.add_chp("chp2", P_el_nom=200, ...)
+configurator.auto_connect_digester_to_chp("digester_1", "chp2")
+
+# Option 4: Gasspeicherkapazität erhöhen
+# (V_gas beim Hinzufügen von Fermentern anpassen)
+```
+
+## Fortgeschrittene Anwendungen
+
+### 1. Parameter-Sweep zur Optimierung
+
+```python
+from pyadm1.simulation import ParallelSimulator
+
+# Verschiedene Temperaturen für Stufe 1 testen
+parallel = ParallelSimulator(adm1, n_workers=4)
+scenarios = [
+    {"T_ad_1": 313.15, "Q": [15, 10, 0, 0, 0, 0, 0, 0, 0, 0]},  # 40°C
+    {"T_ad_1": 318.15, "Q": [15, 10, 0, 0, 0, 0, 0, 0, 0, 0]},  # 45°C
+    {"T_ad_1": 323.15, "Q": [15, 10, 0, 0, 0, 0, 0, 0, 0, 0]},  # 50°C
+]
+results = parallel.run_scenarios(scenarios, duration=30)
+```
+
+### 2. Online-Kalibrierung
+
+```python
+from pyadm1.calibration import Calibrator
+
+# Hydrolyseparameter der Stufe 1 kalibrieren
+calibrator = Calibrator(plant.components["digester_1"])
+params = calibrator.calibrate_initial(
+    measurements=measurement_data,
+    parameters=["k_hyd_ch", "k_hyd_pr", "k_hyd_li"],
+)
+```
+
+### 3. Modellgestützte prädiktive Regelung (MPC)
+
+```python
+# Optimale Fütterung für die nächsten 48 Stunden vorhersagen
+Q_best, Q_ch4_pred = simulator.determine_best_feed_by_n_sims(
+    state_zero=current_state,
+    Q=current_feed,
+    Qch4sp=800,  # Sollwert: 800 m³/d CH4
+    feeding_freq=48,
+    n=20  # Test von 20 Szenarien
+)
+```
+
+## Referenzen
+
+- **TPAD Design**: Simeonov, I., Chorukova, E., & Kabaivanova, L. (2025). *Two-stage anaerobic digestion for green energy production: A review*. Processes, 13(2), 294.
+- **Prozesssteuerung**: Gaida (2014). *Dynamic real-time substrate feed optimization of anaerobic co-digestion plants*. PhD thesis, Leiden University.
+
+## Ähnliche Beispiele
+
+- [`basic_digester.md`](basic_digester.md): Einfaches einstufiges System
+- `calibration_workflow.md`: Parameterschätzung aus Messdaten
+- `substrate_optimization.py`: Optimale Fütterungsstrategie
+- [`parallel_two_stage_simulation.py`](https://github.com/dgaida/PyADM1ODE/blob/master/examples/parallel_two_stage_simulation.py): Parallele Simulationen

--- a/docs/de/index.md
+++ b/docs/de/index.md
@@ -3,6 +3,9 @@
 Willkommen bei PyADM1ODE - Einem Python-Framework zur Modellierung, Simulation und Optimierung von landwirtschaftlichen Biogasanlagen basierend auf dem Anaerobic Digestion Model No. 1 (ADM1).
 
 ## 🎯 Quick Links
+<div align="center">
+  <a href="https://colab.research.google.com/github/dgaida/PyADM1ODE/blob/master/examples/colab_01_basic_digester.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a>
+</div>
 
 <div class="grid cards" markdown>
 
@@ -22,13 +25,13 @@ Willkommen bei PyADM1ODE - Einem Python-Framework zur Modellierung, Simulation u
 
     [:octicons-arrow-right-24: Installations-Anleitung](user_guide/installation.md)
 
--   :material-book-open-variant:{ .lg .middle } __Komponenten-Leitfaden__
+-   :material-book-open-variant:{ .lg .middle } __Handbuch__
 
     ---
 
-    Erfahren Sie mehr über Fermenter, BHKWs, Pumpen und mehr
+    Erfahren Sie mehr über das Framework, Komponenten und Substrate
 
-    [:octicons-arrow-right-24: Komponentendokumentation](user_guide/components/index.md)
+    [:octicons-arrow-right-24: Handbuch](user_guide/adm1_implementation.md)
 
 -   :material-code-braces:{ .lg .middle } __Beispiele__
 
@@ -48,71 +51,6 @@ PyADM1ODE ist ein umfassendes Python-Framework für die Modellierung landwirtsch
 - **Modulare Architektur**: Kombinieren Sie Komponenten (Fermenter, BHKW, Pumpen, Rührwerke), um jede beliebige Anlagenkonfiguration zu erstellen.
 - **Praxisnähe**: Validiert mit Daten von in Betrieb befindlichen Biogasanlagen.
 - **Python-Ökosystem**: Integriert mit NumPy, SciPy, Pandas und Visualisierungsbibliotheken.
-
-### Hauptmerkmale
-
-✨ **Umfassende Komponentenbibliothek**
-
-- Biologisch: Ein-/mehrstufige Fermenter, Hydrolysetanks, Separatoren
-- Energie: BHKW-Einheiten, Heizsysteme, Gasspeicher, Fackeln
-- Mechanisch: Pumpen, Rührwerke mit realistischem Stromverbrauch
-- Fütterung: Substratlagerung, automatisierte Dosiersysteme
-
-🔧 **Flexible Anlagenkonfiguration**
-
-- Erstellen Sie komplexe Anlagen programmatisch oder über Vorlagen
-- Automatische Komponentenverbindung und Validierung
-- Speichern/Laden von Konfigurationen als JSON
-
-📊 **Fortgeschrittene Simulation**
-
-- Parallele Ausführung für Parameterstudien und Monte-Carlo-Analysen
-- Adaptive ODE-Solver, optimiert für steife Biogassysteme
-- Zeitreihen-Datenverarbeitung und Ergebnisanalyse
-
-🎓 **Bildung & Professionell**
-
-- Geeignet für die Lehre im Bereich Biogasanlagendesign
-- Forschungswerkzeug zur Prozessoptimierung
-- Engineering-Anwendungen für die Anlagenplanung
-
-## Systemarchitektur
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                     PyADM1ODE Framework                          │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                  │
-│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐         │
-│  │ Biologische  │  │   Energie-   │  │ Mechanische  │         │
-│  │ Komponenten  │  │ Komponenten  │  │ Komponenten  │         │
-│  ├──────────────┤  ├──────────────┤  ├──────────────┤         │
-│  │ • Fermenter  │  │ • BHKW       │  │ • Pumpen     │         │
-│  │ • Hydrolyse  │  │ • Heizung    │  │ • Rührwerke  │         │
-│  │ • Separatoren│  │ • Speicher   │  │              │         │
-│  │              │  │ • Fackeln    │  │              │         │
-│  └──────────────┘  └──────────────┘  └──────────────┘         │
-│                                                                  │
-│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐         │
-│  │   Fütterung  │  │   Sensoren   │  │ Konfigurator │         │
-│  │ Komponenten  │  │  (geplant)   │  │              │         │
-│  ├──────────────┤  ├──────────────┤  ├──────────────┤         │
-│  │ • Lagerung   │  │ • pH         │  │ • Builder    │         │
-│  │ • Dosierer   │  │ • VFA        │  │ • Vorlagen   │         │
-│  │              │  │ • Gas        │  │ • Validator  │         │
-│  └──────────────┘  └──────────────┘  └──────────────┘         │
-│                                                                  │
-├─────────────────────────────────────────────────────────────────┤
-│                       Kern-ADM1-Engine                           │
-│  • 37 Zustandsvariablen • pH-Dynamik • Gas-Flüssig-Transfer     │
-│  • Temperaturabhängige Kinetik • Inhibitionsmodellierung        │
-├─────────────────────────────────────────────────────────────────┤
-│                    Substratmanagement                            │
-│  • 10 vorkonfigurierte landwirtschaftliche Substrate            │
-│  • Automatische ADM1-Input-Strom-Generierung                    │
-│  • Zeitlich variierende Fütterungspläne                         │
-└─────────────────────────────────────────────────────────────────┘
-```
 
 ## Kurzes Beispiel
 
@@ -155,21 +93,14 @@ print(f"Methan: {final['Q_ch4']:.1f} m³/d")
 print(f"pH: {final['pH']:.2f}")
 ```
 
-**Ausgabe:**
-```
-Biogas: 1245.3 m³/d
-Methan: 748.2 m³/d
-pH: 7.28
-```
+---
 
-## Typische Anwendungen
+## Community und Support
 
-### 1. Anlagendesign und Optimierung
+- **GitHub Repository**: [dgaida/PyADM1ODE](https://github.com/dgaida/PyADM1ODE)
+- **Issue Tracker**: [Bugs melden oder Features anfragen](https://github.com/dgaida/PyADM1ODE/issues)
+- **Discussions**: [Fragen stellen und Ideen austauschen](https://github.com/dgaida/PyADM1ODE/discussions)
 
-### 2. Substratoptimierung
+## Lizenz
 
-### 3. Energiebilanzanalyse
-
-### 4. Zweistufiges Prozessdesign
-
-(Details siehe englische Version oder Unterseiten)
+PyADM1ODE ist Open-Source-Software unter der MIT-Lizenz.

--- a/docs/de/user_guide/advanced_features.md
+++ b/docs/de/user_guide/advanced_features.md
@@ -1,0 +1,38 @@
+# Fortgeschrittene Funktionen
+
+PyADM1ODE bietet fortgeschrittene Funktionen für umfangreiche Studien und das Konfigurationsmanagement.
+
+## Parallele Simulation
+
+Führen Sie mehrere Szenarien gleichzeitig aus, um Parameterstudien oder Monte-Carlo-Simulationen zu beschleunigen.
+
+```python
+from pyadm1.simulation import ParallelSimulator
+
+# Parameterstudie
+parallel = ParallelSimulator(adm1, n_workers=4)
+scenarios = [
+    {"k_dis": 0.5, "Q": [15, 10, 0, 0, 0, 0, 0, 0, 0, 0]},
+    {"k_dis": 0.6, "Q": [15, 10, 0, 0, 0, 0, 0, 0, 0, 0]},
+    {"k_dis": 0.7, "Q": [15, 10, 0, 0, 0, 0, 0, 0, 0, 0]}
+]
+
+results = parallel.run_scenarios(scenarios, duration=30, initial_state=state)
+```
+
+Weitere Details finden Sie im [Beispiel für parallele Simulation](../examples/parallel_simulation.md).
+
+## Konfigurationsmanagement
+
+Speichern und verwenden Sie Anlagendesigns mithilfe der JSON-Serialisierung wieder.
+
+```python
+# Konfiguration speichern
+plant.to_json("zweistufige_anlage.json")
+
+# Später laden
+from pyadm1.configurator import BiogasPlant
+plant = BiogasPlant.from_json("zweistufige_anlage.json", feedstock)
+plant.initialize()
+results = plant.simulate(duration=30, dt=1/24)
+```

--- a/docs/de/user_guide/applications.md
+++ b/docs/de/user_guide/applications.md
@@ -1,0 +1,72 @@
+# Typische Anwendungen
+
+PyADM1ODE kann für eine Vielzahl von Aufgaben eingesetzt werden, vom Anlagendesign bis hin zur Echtzeitoptimierung.
+
+## 1. Anlagendesign und Optimierung
+
+Testen Sie verschiedene Anlagenkonfigurationen, um das optimale Setup für Ihre Bedürfnisse zu finden.
+
+```python
+from pyadm1.configurator import BiogasPlant, PlantConfigurator
+from pyadm1.substrates import Feedstock
+
+# Test verschiedener Fermentergrößen
+for V_liq in [1500, 2000, 2500]:
+    plant = BiogasPlant(f"Anlage_{V_liq}")
+    feedstock = Feedstock()
+    configurator = PlantConfigurator(plant, feedstock)
+    configurator.add_digester("dig1", V_liq=V_liq, Q_substrates=[15, 10, 0, 0, 0, 0, 0, 0, 0, 0])
+
+    plant.initialize()
+    results = plant.simulate(duration=30, dt=1/24)
+
+    final = results[-1]["components"]["dig1"]
+    print(f"V={V_liq} m³ → CH4={final['Q_ch4']:.1f} m³/d")
+```
+
+## 2. Substratoptimierung
+
+Vergleichen Sie verschiedene Substratbelegungen, um die Methanproduktion zu maximieren oder die Kosten zu minimieren.
+
+```python
+# Vergleich verschiedener Substratbelegungen
+mixes = {
+    'high_energy': [20, 5, 0, 0, 0, 0, 0, 0, 0, 0],
+    'balanced': [15, 10, 0, 0, 0, 0, 0, 0, 0, 0],
+    'waste_based': [0, 15, 0, 0, 0, 0, 0, 0, 10, 5]
+}
+
+for name, Q in mixes.items():
+    # ... konfigurieren und simulieren ...
+    print(f"{name}: {final['Q_ch4']:.1f} m³/d Methan")
+```
+
+## 3. Energiebilanzanalyse
+
+Analysieren Sie die Nettoenergieerzeugung und den Eigenverbrauch Ihrer Anlage.
+
+```python
+# Berechnung der Nettoenergieerzeugung
+chp_power = results[-1]["components"]["chp_main"]["P_el"]
+mixer_power = results[-1]["components"]["mixer_1"]["P_consumed"]
+pump_power = results[-1]["components"]["pump_1"]["P_consumed"]
+
+eigenverbrauch = mixer_power + pump_power
+netto_leistung = chp_power - eigenverbrauch
+
+print(f"Nettoleistung: {netto_leistung:.1f} kW")
+print(f"Eigenverbrauchsquote: {eigenverbrauch/chp_power:.1%}")
+```
+
+## 4. Zweistufiges Prozessdesign
+
+Modellieren Sie fortgeschrittene Anlagendesigns wie die temperaturgestufte anaerobe Vergärung (TPAD).
+
+```python
+# Temperaturgestufte anaerobe Vergärung (TPAD)
+configurator.add_digester("hydrolyse", V_liq=500, T_ad=318.15)  # 45°C
+configurator.add_digester("hauptfermenter", V_liq=2000, T_ad=308.15)       # 35°C
+configurator.connect("hydrolyse", "hauptfermenter", "liquid")
+
+# Verbesserte Hydrolyse in Stufe 1, stabile Methanogenese in Stufe 2
+```

--- a/docs/de/user_guide/substrates.md
+++ b/docs/de/user_guide/substrates.md
@@ -1,0 +1,28 @@
+# Vorkonfigurierte Substrate
+
+PyADM1ODE enthält 10 landwirtschaftliche Substrate mit in der Literatur validierten Parametern.
+
+## Verfügbare Substrate
+
+| Substrat | Typ | Typische Verwendung | Biogaspotenzial |
+|----------|-----|--------------------|-----------------|
+| **Maissilage** | Energiepflanze | Hauptsubstrat | Hoch (600-700 L/kg VS) |
+| **Gülle** | Tierische Abfälle | Co-Substrat | Mittel (200-400 L/kg VS) |
+| **Grünroggen** | Energiepflanze | Frühernte | Mittel-Hoch |
+| **Grassilage** | Grünland | Erneuerbar | Mittel (400-550 L/kg VS) |
+| **Weizen** | Getreide | Energiepflanze | Hoch |
+| **GPS** | Ganzpflanzensilage | Ganze Pflanze | Hoch |
+| **CCM** | Corn-Cob-Mix | Energiepflanze | Hoch |
+| **Futterkalk** | Zusatzstoff | pH-Puffer | N/V |
+| **Rindergülle** | Tierische Abfälle | Co-Substrat | Mittel (200-350 L/kg VS) |
+| **Zwiebeln** | Abfall | Gemüseabfälle | Mittel-Hoch |
+
+## Substratcharakterisierung
+
+Alle Substrate sind charakterisiert durch:
+- Trockensubstanz (TS) und organische Trockensubstanz (oTS)
+- ADM1-Fraktionierung (Kohlenhydrate, Proteine, Lipide)
+- Biochemisches Methanpotenzial (BMP)
+- pH-Wert und Alkalinität
+
+Weitere Details zur Abbildung auf ADM1 finden Sie auf der Seite [ADM1-Implementierung](adm1_implementation.md).

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -3,6 +3,9 @@
 Welcome to PyADM1ODE - A Python framework for modeling, simulating, and optimizing agricultural biogas plants based on the Anaerobic Digestion Model No. 1 (ADM1).
 
 ## 🎯 Quick Links
+<div align="center">
+  <a href="https://colab.research.google.com/github/dgaida/PyADM1ODE/blob/master/examples/colab_01_basic_digester.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"></a>
+</div>
 
 <div class="grid cards" markdown>
 
@@ -22,13 +25,13 @@ Welcome to PyADM1ODE - A Python framework for modeling, simulating, and optimizi
 
     [:octicons-arrow-right-24: Installation Guide](user_guide/installation.md)
 
--   :material-book-open-variant:{ .lg .middle } __Components Guide__
+-   :material-book-open-variant:{ .lg .middle } __User Guide__
 
     ---
 
-    Learn about digesters, CHP units, pumps, and more
+    Learn about the framework, components, and substrates
 
-    [:octicons-arrow-right-24: Component Documentation](user_guide/components/index.md)
+    [:octicons-arrow-right-24: Handbuch](user_guide/adm1_implementation.md)
 
 -   :material-code-braces:{ .lg .middle } __Examples__
 
@@ -44,75 +47,10 @@ Welcome to PyADM1ODE - A Python framework for modeling, simulating, and optimizi
 
 PyADM1ODE is a comprehensive Python framework for agricultural biogas plant modeling that combines:
 
-- **Scientific accuracy**: Based on IWA's ADM1 model, the international standard for anaerobic digestion
-- **Modular architecture**: Mix and match components (digesters, CHP units, pumps, mixers) to build any plant configuration
-- **Real-world applicability**: Validated with data from operating biogas plants
-- **Python ecosystem**: Integrates with NumPy, SciPy, Pandas, and visualization libraries
-
-### Key Features
-
-✨ **Comprehensive Component Library**  
-
-- Biological: Single/multi-stage digesters, hydrolysis tanks, separators  
-- Energy: CHP units, heating systems, gas storage, flares  
-- Mechanical: Pumps, mixers with realistic power consumption  
-- Feeding: Substrate storage, automated dosing systems
-
-🔧 **Flexible Plant Configuration**  
-
-- Build complex plants programmatically or via templates  
-- Automatic component connection and validation  
-- Save/load configurations as JSON
-
-📊 **Advanced Simulation**  
-
-- Parallel execution for parameter sweeps and Monte Carlo analysis  
-- Adaptive ODE solvers optimized for stiff biogas systems  
-- Time-series data handling and result analysis
-
-🎓 **Educational & Professional**  
-
-- Suitable for teaching biogas plant design  
-- Research tool for process optimization  
-- Engineering applications for plant planning
-
-## System Architecture
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                     PyADM1ODE Framework                          │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                  │
-│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐         │
-│  │   Biological │  │    Energy    │  │  Mechanical  │         │
-│  │  Components  │  │  Components  │  │  Components  │         │
-│  ├──────────────┤  ├──────────────┤  ├──────────────┤         │
-│  │ • Digesters  │  │ • CHP Units  │  │ • Pumps      │         │
-│  │ • Hydrolysis │  │ • Heating    │  │ • Mixers     │         │
-│  │ • Separators │  │ • Storage    │  │              │         │
-│  │              │  │ • Flares     │  │              │         │
-│  └──────────────┘  └──────────────┘  └──────────────┘         │
-│                                                                  │
-│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐         │
-│  │   Feeding    │  │   Sensors    │  │ Configurator │         │
-│  │  Components  │  │  (planned)   │  │              │         │
-│  ├──────────────┤  ├──────────────┤  ├──────────────┤         │
-│  │ • Storage    │  │ • pH         │  │ • Builder    │         │
-│  │ • Feeders    │  │ • VFA        │  │ • Templates  │         │
-│  │              │  │ • Gas        │  │ • Validator  │         │
-│  └──────────────┘  └──────────────┘  └──────────────┘         │
-│                                                                  │
-├─────────────────────────────────────────────────────────────────┤
-│                       Core ADM1 Engine                           │
-│  • 37 state variables • pH dynamics • Gas-liquid transfer       │
-│  • Temperature-dependent kinetics • Inhibition modeling         │
-├─────────────────────────────────────────────────────────────────┤
-│                    Substrate Management                          │
-│  • 10 pre-configured agricultural substrates                    │
-│  • Automatic ADM1 input stream generation                       │
-│  • Time-varying feed schedules                                  │
-└─────────────────────────────────────────────────────────────────┘
-```
+- **Scientific accuracy**: Based on IWA's ADM1 model, the international standard for anaerobic digestion.
+- **Modular architecture**: Mix and match components (digesters, CHP units, pumps, mixers) to build any plant configuration.
+- **Real-world applicability**: Validated with data from operating biogas plants.
+- **Python ecosystem**: Integrates with NumPy, SciPy, Pandas, and visualization libraries.
 
 ## Quick Example
 
@@ -155,308 +93,14 @@ print(f"Methane: {final['Q_ch4']:.1f} m³/d")
 print(f"pH: {final['pH']:.2f}")
 ```
 
-**Output:**
-```
-Biogas: 1245.3 m³/d
-Methane: 748.2 m³/d
-pH: 7.28
-```
-
-## Typical Applications
-
-### 1. Plant Design and Optimization
-
-```python
-# Test different digester sizes
-for V_liq in [1500, 2000, 2500]:
-    plant = BiogasPlant(f"Plant_{V_liq}")
-    configurator = PlantConfigurator(plant, feedstock)
-    configurator.add_digester("dig1", V_liq=V_liq, Q_substrates=[15, 10, 0, 0, 0, 0, 0, 0, 0, 0])
-
-    plant.initialize()
-    results = plant.simulate(duration=30, dt=1/24)
-
-    final = results[-1]["components"]["dig1"]
-    print(f"V={V_liq} m³ → CH4={final['Q_ch4']:.1f} m³/d")
-```
-
-### 2. Substrate Optimization
-
-```python
-# Compare different substrate mixes
-mixes = {
-    'high_energy': [20, 5, 0, 0, 0, 0, 0, 0, 0, 0],
-    'balanced': [15, 10, 0, 0, 0, 0, 0, 0, 0, 0],
-    'waste_based': [0, 15, 0, 0, 0, 0, 0, 0, 10, 5]
-}
-
-for name, Q in mixes.items():
-    # ... configure and simulate ...
-    print(f"{name}: {final['Q_ch4']:.1f} m³/d methane")
-```
-
-### 3. Energy Balance Analysis
-
-```python
-# Calculate net energy production
-chp_power = results[-1]["components"]["chp_main"]["P_el"]
-mixer_power = results[-1]["components"]["mixer_1"]["P_consumed"]
-pump_power = results[-1]["components"]["pump_1"]["P_consumed"]
-
-parasitic_load = mixer_power + pump_power
-net_power = chp_power - parasitic_load
-
-print(f"Net power: {net_power:.1f} kW")
-print(f"Parasitic ratio: {parasitic_load/chp_power:.1%}")
-```
-
-### 4. Two-Stage Process Design
-
-```python
-# Temperature-phased anaerobic digestion (TPAD)
-configurator.add_digester("hydrolysis", V_liq=500, T_ad=318.15)  # 45°C
-configurator.add_digester("main", V_liq=2000, T_ad=308.15)       # 35°C
-configurator.connect("hydrolysis", "main", "liquid")
-
-# Enhanced hydrolysis in stage 1, stable methanogenesis in stage 2
-```
-
-## Component Categories
-
-### Biological Components
-
-Model the core biological processes:
-
-- **[Digester](user_guide/components/biological.md#digester)**: Main fermenter with ADM1 model
-  - Single or multi-stage configurations
-  - Temperature control (psychrophilic, mesophilic, thermophilic)
-  - Automatic gas storage creation
-  - Calibration parameter support (using [PyADM1ODE_calibration](https://github.com/dgaida/PyADM1ODE_calibration))
-
-- **[Hydrolysis](user_guide/components/biological.md#hydrolysis)**: Pre-treatment tank (planned)
-- **[Separator](user_guide/components/biological.md#separator)**: Digestate processing (planned)
-
-### Energy Components
-
-Complete energy integration:
-
-- **[CHP](user_guide/components/energy.md#chp-combined-heat-and-power)**: Combined heat and power generation
-    - Variable efficiency curves
-    - Load-following operation
-    - Automatic flare creation
-
-- **[Heating](user_guide/components/energy.md#heating)**: Temperature control systems
-    - CHP waste heat utilization
-    - Auxiliary heating calculation
-
-- **[Gas Storage](user_guide/components/energy.md#gas-storage)**: Biogas buffering
-    - Low-pressure (membrane, dome) and high-pressure options
-    - Automatic pressure management
-    - Safety venting
-
-- **[Flare](user_guide/components/energy.md#flare)**: Safety gas combustion
-    - 98% methane destruction efficiency
-    - Automatic activation on overpressure
-
-### Mechanical Components
-
-Material handling and process control:
-
-- **[Pump](user_guide/components/mechanical.md#pump)**: Substrate and digestate transfer
-    - Progressive cavity, centrifugal, piston types
-    - Power consumption modeling
-    - Variable frequency drive support
-
-- **[Mixer](user_guide/components/mechanical.md#mixer)**: Digester agitation
-    - Propeller, paddle, jet mixer types
-    - Intermittent operation for energy savings
-    - Reynolds number and mixing time calculation
-
-### Feeding Components
-
-Substrate management:
-
-- **[Substrate Storage](user_guide/components/feeding.md#substrate-storage)**: Material inventory
-    - Multiple storage types (silos, tanks, bunkers)
-    - Quality degradation modeling
-    - Capacity and utilization tracking
-
-- **[Feeder](user_guide/components/feeding.md#feeder)**: Automated dosing
-    - Screw, piston, progressive cavity feeders
-    - Realistic dosing accuracy and noise
-    - Blockage detection
-
-## Pre-configured Substrates
-
-PyADM1ODE includes 10 agricultural substrates with literature-validated parameters:
-
-| Substrate | Type | Typical Use | Biogas Potential |
-|-----------|------|-------------|------------------|
-| **Corn silage** | Energy crop | Main feedstock | High (600-700 L/kg VS) |
-| **Liquid manure** | Animal waste | Co-substrate | Medium (200-400 L/kg VS) |
-| **Green rye** | Energy crop | Early harvest | Medium-High |
-| **Grass silage** | Grassland | Renewable | Medium (400-550 L/kg VS) |
-| **Wheat** | Cereal | Energy crop | High |
-| **GPS** | Grain silage | Whole-crop | High |
-| **CCM** | Corn-cob-mix | Energy crop | High |
-| **Feed lime** | Additive | pH buffer | N/A |
-| **Cow manure** | Animal waste | Co-substrate | Medium (200-350 L/kg VS) |
-| **Onions** | Waste | Vegetable waste | Medium-High |
-
-All substrates are characterized with:  
-- Dry matter (DM) and volatile solids (VS) content  
-- ADM1 fractionation (carbohydrates, proteins, lipids)  
-- Biochemical methane potential (BMP)  
-- pH and alkalinity
-
-## Advanced Features
-
-### Parallel Simulation
-
-Run multiple scenarios concurrently (see [Example: Parallel Simulation](examples/parallel_simulation.md)):
-
-```python
-from pyadm1.simulation import ParallelSimulator
-
-# Parameter sweep
-parallel = ParallelSimulator(adm1, n_workers=4)
-scenarios = [
-    {"k_dis": 0.5, "Q": [15, 10, 0, 0, 0, 0, 0, 0, 0, 0]},
-    {"k_dis": 0.6, "Q": [15, 10, 0, 0, 0, 0, 0, 0, 0, 0]},
-    {"k_dis": 0.7, "Q": [15, 10, 0, 0, 0, 0, 0, 0, 0, 0]}
-]
-
-results = parallel.run_scenarios(scenarios, duration=30, initial_state=state)
-```
-
-### Configuration Management
-
-Save and reuse plant designs:
-
-```python
-# Save configuration
-plant.to_json("two_stage_plant.json")
-
-# Load later
-plant = BiogasPlant.from_json("two_stage_plant.json", feedstock)
-plant.initialize()
-results = plant.simulate(duration=30, dt=1/24)
-```
-
-## Scientific Foundation
-
-PyADM1ODE is based on the **Anaerobic Digestion Model No. 1 (ADM1)**, developed by the International Water Association (IWA) Task Group:
-
-- **37 state variables**: Complete representation of liquid and gas phases
-- **19 biochemical processes**: Disintegration, hydrolysis, acidogenesis, acetogenesis, methanogenesis
-- **Temperature-dependent kinetics**: Arrhenius relationships for all rate constants
-- **pH dynamics**: Full acid-base equilibrium with 6 ionic species
-- **Gas-liquid transfer**: Henry's law implementation for H₂, CH₄, CO₂
-- **Inhibition modeling**: pH, ammonia, and hydrogen inhibition
-
-**Key References:**
-
-- Batstone, D.J., et al. (2002). *Anaerobic Digestion Model No. 1 (ADM1)*. IWA Publishing.
-- Sadrimajd, P., et al. (2021). *[PyADM1](https://github.com/CaptainFerMag/PyADM1): a Python implementation of Anaerobic Digestion Model No. 1*. bioRxiv.
-
-## Installation
-
-Install PyADM1ODE via pip (not yet existing):
-
-```bash
-pip install pyadm1ode
-```
-
-For development or the latest features:
-
-```bash
-git clone https://github.com/dgaida/PyADM1ODE.git
-cd PyADM1ODE
-pip install -e .
-```
-
-**Platform-specific requirements:**  
-- **Linux/macOS**: Mono runtime (for C# DLLs)  
-- **Windows**: .NET Framework (usually pre-installed)
-
-See the [Installation Guide](user_guide/installation.md) for detailed instructions.
-
-## Getting Started
-
-1. **[Install PyADM1ODE](user_guide/installation.md)** on your system
-2. **[Follow the Quickstart](user_guide/quickstart.md)** to run your first simulation
-3. **[Explore Components](user_guide/components/index.md)** to understand available building blocks
-4. **[Study Examples](examples/basic_digester.md)** for real-world applications
-
-## Extension Packages
-
-### PyADM1ODE_mcp - LLM-Driven Plant Design
-
-Natural language interface for biogas plant modeling:
-
-```bash
-git clone https://github.com/dgaida/PyADM1ODE_mcp.git
-cd PyADM1ODE_mcp
-pip install -e .
-```
-
-**Features:**  
-- Interact with Claude or other LLMs to design plants via natural language  
-- MCP server for seamless LLM integration  
-- Automated configuration parsing and validation
-
-**Use case:** *"Design a two-stage biogas plant with 2000 m³ main digester, 500 m³ hydrolysis tank at 45°C, and a 500 kW CHP unit. Use corn silage and cattle manure as substrates."*
-
-### PyADM1ODE_calibration - Parameter Estimation
-
-Automated model calibration from measurement data:
-
-```bash
-git clone https://github.com/dgaida/PyADM1ODE_calibration.git
-cd PyADM1ODE_calibration
-pip install -e .
-```
-
-**Features:**  
-- Initial calibration from historical data  
-- Online re-calibration during operation  
-- Multiple optimization algorithms (Differential Evolution, PSO, Nelder-Mead)  
-- Comprehensive validation metrics
-
-**Use case:** Fit ADM1 parameters to real plant measurements for accurate predictions.
+---
 
 ## Community and Support
 
 - **GitHub Repository**: [dgaida/PyADM1ODE](https://github.com/dgaida/PyADM1ODE)
 - **Issue Tracker**: [Report bugs or request features](https://github.com/dgaida/PyADM1ODE/issues)
 - **Discussions**: [Ask questions and share ideas](https://github.com/dgaida/PyADM1ODE/discussions)
-- **Email**: daniel.gaida@th-koeln.de
 
 ## License
 
 PyADM1ODE is open-source software licensed under the MIT License.
-
-## Citation
-
-If you use PyADM1ODE in your research, please cite:
-
-```bibtex
-@software{gaida2025pyadm1ode,
-  author = {Gaida, Daniel; Nordhoff, Tim Yago},
-  title = {PyADM1ODE: Python Framework for Agricultural Biogas Plant Modeling},
-  year = {2026},
-  url = {https://github.com/dgaida/PyADM1ODE}
-}
-```
-
-## Acknowledgments
-
-PyADM1ODE builds upon:
-
-- **IWA ADM1 Task Group** - Original model development
-- **[PyADM1](https://github.com/CaptainFerMag/PyADM1)** by Sadrimajd et al. - Initial Python implementation
-- **SIMBA#biogas** - Substrate characterization and validation data
-
----
-
-**Ready to start?** Head over to the [Quickstart Guide](user_guide/quickstart.md) and build your first biogas plant in minutes! 🚀

--- a/docs/en/user_guide/advanced_features.md
+++ b/docs/en/user_guide/advanced_features.md
@@ -1,0 +1,38 @@
+# Advanced Features
+
+PyADM1ODE provides advanced features for large-scale studies and configuration management.
+
+## Parallel Simulation
+
+Run multiple scenarios concurrently to speed up parameter sweeps or Monte Carlo simulations.
+
+```python
+from pyadm1.simulation import ParallelSimulator
+
+# Parameter sweep
+parallel = ParallelSimulator(adm1, n_workers=4)
+scenarios = [
+    {"k_dis": 0.5, "Q": [15, 10, 0, 0, 0, 0, 0, 0, 0, 0]},
+    {"k_dis": 0.6, "Q": [15, 10, 0, 0, 0, 0, 0, 0, 0, 0]},
+    {"k_dis": 0.7, "Q": [15, 10, 0, 0, 0, 0, 0, 0, 0, 0]}
+]
+
+results = parallel.run_scenarios(scenarios, duration=30, initial_state=state)
+```
+
+See the [Parallel Simulation Example](../examples/parallel_simulation.md) for more details.
+
+## Configuration Management
+
+Save and reuse plant designs using JSON serialization.
+
+```python
+# Save configuration
+plant.to_json("two_stage_plant.json")
+
+# Load later
+from pyadm1.configurator import BiogasPlant
+plant = BiogasPlant.from_json("two_stage_plant.json", feedstock)
+plant.initialize()
+results = plant.simulate(duration=30, dt=1/24)
+```

--- a/docs/en/user_guide/applications.md
+++ b/docs/en/user_guide/applications.md
@@ -1,0 +1,72 @@
+# Typical Applications
+
+PyADM1ODE can be used for a wide range of tasks, from plant design to real-time optimization.
+
+## 1. Plant Design and Optimization
+
+Test different plant configurations to find the optimal setup for your needs.
+
+```python
+from pyadm1.configurator import BiogasPlant, PlantConfigurator
+from pyadm1.substrates import Feedstock
+
+# Test different digester sizes
+for V_liq in [1500, 2000, 2500]:
+    plant = BiogasPlant(f"Plant_{V_liq}")
+    feedstock = Feedstock()
+    configurator = PlantConfigurator(plant, feedstock)
+    configurator.add_digester("dig1", V_liq=V_liq, Q_substrates=[15, 10, 0, 0, 0, 0, 0, 0, 0, 0])
+
+    plant.initialize()
+    results = plant.simulate(duration=30, dt=1/24)
+
+    final = results[-1]["components"]["dig1"]
+    print(f"V={V_liq} m³ → CH4={final['Q_ch4']:.1f} m³/d")
+```
+
+## 2. Substrate Optimization
+
+Compare different substrate mixes to maximize methane production or minimize costs.
+
+```python
+# Compare different substrate mixes
+mixes = {
+    'high_energy': [20, 5, 0, 0, 0, 0, 0, 0, 0, 0],
+    'balanced': [15, 10, 0, 0, 0, 0, 0, 0, 0, 0],
+    'waste_based': [0, 15, 0, 0, 0, 0, 0, 0, 10, 5]
+}
+
+for name, Q in mixes.items():
+    # ... configure and simulate ...
+    print(f"{name}: {final['Q_ch4']:.1f} m³/d methane")
+```
+
+## 3. Energy Balance Analysis
+
+Analyze the net energy production and parasitic loads of your plant.
+
+```python
+# Calculate net energy production
+chp_power = results[-1]["components"]["chp_main"]["P_el"]
+mixer_power = results[-1]["components"]["mixer_1"]["P_consumed"]
+pump_power = results[-1]["components"]["pump_1"]["P_consumed"]
+
+parasitic_load = mixer_power + pump_power
+net_power = chp_power - parasitic_load
+
+print(f"Net power: {net_power:.1f} kW")
+print(f"Parasitic ratio: {parasitic_load/chp_power:.1%}")
+```
+
+## 4. Two-Stage Process Design
+
+Model advanced plant designs like Temperature-Phased Anaerobic Digestion (TPAD).
+
+```python
+# Temperature-phased anaerobic digestion (TPAD)
+configurator.add_digester("hydrolysis", V_liq=500, T_ad=318.15)  # 45°C
+configurator.add_digester("main", V_liq=2000, T_ad=308.15)       # 35°C
+configurator.connect("hydrolysis", "main", "liquid")
+
+# Enhanced hydrolysis in stage 1, stable methanogenesis in stage 2
+```

--- a/docs/en/user_guide/substrates.md
+++ b/docs/en/user_guide/substrates.md
@@ -1,0 +1,28 @@
+# Pre-configured Substrates
+
+PyADM1ODE includes 10 agricultural substrates with literature-validated parameters.
+
+## Available Substrates
+
+| Substrate | Type | Typical Use | Biogas Potential |
+|-----------|------|-------------|------------------|
+| **Corn silage** | Energy crop | Main feedstock | High (600-700 L/kg VS) |
+| **Liquid manure** | Animal waste | Co-substrate | Medium (200-400 L/kg VS) |
+| **Green rye** | Energy crop | Early harvest | Medium-High |
+| **Grass silage** | Grassland | Renewable | Medium (400-550 L/kg VS) |
+| **Wheat** | Cereal | Energy crop | High |
+| **GPS** | Grain silage | Whole-crop | High |
+| **CCM** | Corn-cob-mix | Energy crop | High |
+| **Feed lime** | Additive | pH buffer | N/A |
+| **Cow manure** | Animal waste | Co-substrate | Medium (200-350 L/kg VS) |
+| **Onions** | Waste | Vegetable waste | Medium-High |
+
+## Substrate Characterization
+
+All substrates are characterized with:
+- Dry matter (DM) and volatile solids (VS) content
+- ADM1 fractionation (carbohydrates, proteins, lipids)
+- Biochemical methane potential (BMP)
+- pH and alkalinity
+
+For more details on how these are mapped to ADM1, see the [ADM1 Implementation](adm1_implementation.md) page.

--- a/examples/colab_01_basic_digester.ipynb
+++ b/examples/colab_01_basic_digester.ipynb
@@ -1,0 +1,155 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# PyADM1ODE: Basic Digester Example\n",
+    "\n",
+    "This notebook demonstrates the simplest possible PyADM1 configuration: a single digester with substrate feed and integrated gas storage.\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/dgaida/PyADM1ODE/blob/master/examples/colab_01_basic_digester.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Setup Environment\n",
+    "\n",
+    "We need to install the necessary dependencies, including Mono (for .NET compatibility) and the `pyadm1` package."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install Mono and other dependencies\n",
+    "!apt-get update\n",
+    "!apt-get install -y mono-devel\n",
+    "\n",
+    "# Clone the repository and install pyadm1\n",
+    "!git clone https://github.com/dgaida/PyADM1ODE.git\n",
+    "%cd PyADM1ODE\n",
+    "!pip install -e ."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Import Libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from pathlib import Path\n",
+    "import numpy as np\n",
+    "from pyadm1.configurator.plant_builder import BiogasPlant\n",
+    "from pyadm1.substrates.feedstock import Feedstock\n",
+    "from pyadm1.core.adm1 import get_state_zero_from_initial_state\n",
+    "from pyadm1.configurator.plant_configurator import PlantConfigurator"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Run Simulation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Setup paths\n",
+    "data_path = Path(\"data/initial_states\")\n",
+    "initial_state_file = data_path / \"digester_initial8.csv\"\n",
+    "\n",
+    "# 1. Create feedstock\n",
+    "feeding_freq = 48\n",
+    "feedstock = Feedstock(feeding_freq=feeding_freq)\n",
+    "\n",
+    "# 2. Load initial state from CSV\n",
+    "adm1_state = get_state_zero_from_initial_state(str(initial_state_file))\n",
+    "\n",
+    "# 3. Create biogas plant\n",
+    "plant = BiogasPlant(\"Quickstart Plant\")\n",
+    "configurator = PlantConfigurator(plant, feedstock)\n",
+    "\n",
+    "# 4. Define substrate feed (Corn silage: 15 m³/d, Manure: 10 m³/d)\n",
+    "Q_substrates = [15, 10, 0, 0, 0, 0, 0, 0, 0, 0]\n",
+    "\n",
+    "# 5. Add digester\n",
+    "configurator.add_digester(\n",
+    "    digester_id=\"main_digester\",\n",
+    "    V_liq=2000.0,\n",
+    "    V_gas=300.0,\n",
+    "    T_ad=308.15,  # 35°C\n",
+    "    name=\"Main Digester\",\n",
+    "    load_initial_state=True,\n",
+    "    initial_state_file=str(initial_state_file),\n",
+    "    Q_substrates=Q_substrates,\n",
+    ")\n",
+    "\n",
+    "# 6. Initialize and simulate\n",
+    "plant.initialize()\n",
+    "results = plant.simulate(duration=5.0, dt=1.0/24.0, save_interval=1.0)\n",
+    "\n",
+    "print(\"\\nSimulation completed successfully!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Analyze Results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for result in results:\n",
+    "    time = result[\"time\"]\n",
+    "    comp_results = result[\"components\"][\"main_digester\"]\n",
+    "    print(f\"Day {time:.1f}:\")\n",
+    "    print(f\"  Biogas:  {comp_results.get('Q_gas', 0):>8.1f} m³/d\")\n",
+    "    print(f\"  Methane: {comp_results.get('Q_ch4', 0):>8.1f} m³/d\")\n",
+    "    print(f\"  pH:      {comp_results.get('pH', 0):>8.2f}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/colab_02_complex_plant.ipynb
+++ b/examples/colab_02_complex_plant.ipynb
@@ -1,0 +1,161 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# PyADM1ODE: Complex Two-Stage Plant Example\n",
+    "\n",
+    "This notebook demonstrates a two-stage biogas plant with mechanical components (pumps, mixers) and energy integration (CHP, heating).\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/dgaida/PyADM1ODE/blob/master/examples/colab_02_complex_plant.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Setup Environment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install Mono and other dependencies\n",
+    "!apt-get update\n",
+    "!apt-get install -y mono-devel\n",
+    "\n",
+    "# Clone the repository and install pyadm1\n",
+    "!git clone https://github.com/dgaida/PyADM1ODE.git\n",
+    "%cd PyADM1ODE\n",
+    "!pip install -e ."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Import Libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from pathlib import Path\n",
+    "from pyadm1.configurator.plant_builder import BiogasPlant\n",
+    "from pyadm1.substrates.feedstock import Feedstock\n",
+    "from pyadm1.configurator.plant_configurator import PlantConfigurator\n",
+    "from pyadm1.components.mechanical.mixer import Mixer\n",
+    "from pyadm1.components.mechanical.pump import Pump"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Configure and Run Simulation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "initial_state_file = \"data/initial_states/digester_initial8.csv\"\n",
+    "\n",
+    "# 1. Create feedstock\n",
+    "feedstock = Feedstock(feeding_freq=48)\n",
+    "plant = BiogasPlant(\"Two-Stage Plant\")\n",
+    "configurator = PlantConfigurator(plant, feedstock)\n",
+    "\n",
+    "# 2. Add Stage 1 (Hydrolysis)\n",
+    "configurator.add_digester(\n",
+    "    digester_id=\"digester_1\",\n",
+    "    V_liq=1977.0,\n",
+    "    V_gas=304.0,\n",
+    "    T_ad=318.15,  # 45°C\n",
+    "    load_initial_state=True,\n",
+    "    initial_state_file=initial_state_file,\n",
+    "    Q_substrates=[15, 10, 0, 0, 0, 0, 0, 0, 0, 0]\n",
+    ")\n",
+    "\n",
+    "# 3. Add Stage 2 (Methanogenesis)\n",
+    "configurator.add_digester(\n",
+    "    digester_id=\"digester_2\",\n",
+    "    V_liq=1000.0,\n",
+    "    V_gas=150.0,\n",
+    "    T_ad=308.15,  # 35°C\n",
+    "    load_initial_state=True,\n",
+    "    initial_state_file=initial_state_file,\n",
+    "    Q_substrates=[0, 0, 0, 0, 0, 0, 0, 0, 0, 0]\n",
+    ")\n",
+    "\n",
+    "# 4. Add CHP and Heating\n",
+    "configurator.add_chp(\"chp_1\", P_el_nom=500.0)\n",
+    "configurator.add_heating(\"heating_1\", target_temperature=318.15)\n",
+    "configurator.add_heating(\"heating_2\", target_temperature=308.15)\n",
+    "\n",
+    "# 5. Connect components\n",
+    "configurator.connect(\"digester_1\", \"digester_2\", \"liquid\")\n",
+    "configurator.auto_connect_digester_to_chp(\"digester_1\", \"chp_1\")\n",
+    "configurator.auto_connect_digester_to_chp(\"digester_2\", \"chp_1\")\n",
+    "configurator.auto_connect_chp_to_heating(\"chp_1\", \"heating_1\")\n",
+    "configurator.auto_connect_chp_to_heating(\"chp_1\", \"heating_2\")\n",
+    "\n",
+    "# 6. Initialize and simulate\n",
+    "plant.initialize()\n",
+    "results = plant.simulate(duration=5.0, dt=1.0/24.0, save_interval=1.0)\n",
+    "\n",
+    "print(\"\\nSimulation completed successfully!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Analyze Results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "final = results[-1][\"components\"]\n",
+    "print(f\"Total Biogas:  {final['digester_1']['Q_gas'] + final['digester_2']['Q_gas']:.1f} m³/d\")\n",
+    "print(f\"Total Methane: {final['digester_1']['Q_ch4'] + final['digester_2']['Q_ch4']:.1f} m³/d\")\n",
+    "print(f\"CHP Power:     {final['chp_1']['P_el']:.1f} kW\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,10 +88,9 @@ markdown_extensions:
 
 nav:
   - Home: index.md
-  - Erste Schritte:
+  - Handbuch:
       - Installation: user_guide/installation.md
       - Schnellstart: user_guide/quickstart.md
-  - Dokumentation:
       - ADM1-Implementierung: user_guide/adm1_implementation.md
       - Komponenten:
           - Übersicht: user_guide/components/index.md
@@ -100,16 +99,18 @@ nav:
           - Fütterung: user_guide/components/feeding.md
           - Mechanisch: user_guide/components/mechanical.md
           - Sensoren: user_guide/components/sensors.md
-      - Beispiele:
-          - Basis-Fermenter: examples/basic_digester.md
-          - Zweistufige Anlage: examples/two_stage_plant.md
-          - Parallele Simulation: examples/parallel_simulation.md
+      - Substrate: user_guide/substrates.md
+      - Anwendungen: user_guide/applications.md
+      - Fortgeschrittene Funktionen: user_guide/advanced_features.md
       - Architektur: architecture/index.md
-      - Entwicklung:
-          - Styleguide: development/style_guide.md
-  - Fehlerbehebung: user_guide/troubleshooting.md
-  - Metriken: metrics.md
-  - Changelog: CHANGELOG.md
+      - Fehlerbehebung: user_guide/troubleshooting.md
+  - Beispiele:
+      - Basis-Fermenter: examples/basic_digester.md
+      - Zweistufige Anlage: examples/two_stage_plant.md
+      - Parallele Simulation: examples/parallel_simulation.md
+  - Entwicklung:
+      - Styleguide: development/style_guide.md
+      - Metriken: metrics.md
   - API-Referenz:
       - Core: api/core.md
       - Biologisch: api/biological.md
@@ -119,6 +120,7 @@ nav:
       - Konfigurator: api/configurator.md
       - Simulation: api/simulation.md
       - Substrate: api/substrates.md
+  - Changelog: CHANGELOG.md
 
 extra:
   social:


### PR DESCRIPTION
This PR improves the PyADM1ODE documentation by:
1. Restructuring the homepages (DE/EN) to be more concise landing pages.
2. Moving detailed content (Architecture, Components, Substrates, etc.) to dedicated sub-pages in the manual.
3. Translating all English example pages into German.
4. Adding two Jupyter notebooks for Google Colab to allow users to run simulations in the browser.
5. Organizing the MkDocs navigation with top-level entries for Handbuch (Manual), Beispiele (Examples), and Entwicklung (Development).
6. Adding "Open in Colab" badges to relevant documentation pages.

---
*PR created automatically by Jules for task [3660101932611991235](https://jules.google.com/task/3660101932611991235) started by @dgaida*