### PR TITLE
Add Google Colab badges and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# Use an official Python runtime as a parent image
+FROM python:3.11-slim
+
+# Set environment variables
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+# Install system dependencies including Mono for .NET support
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    mono-complete \
+    build-essential \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set work directory
+WORKDIR /app
+
+# Install Python dependencies
+COPY requirements.txt /app/
+RUN pip install --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt
+
+# Copy the project files
+COPY . /app/
+
+# Install the package in editable mode
+RUN pip install -e .
+
+# Expose port if needed (e.g., for Jupyter)
+EXPOSE 8888
+
+# Create a directory for outputs
+RUN mkdir -p output
+
+# Default command: run the basic digester example
+CMD ["python", "examples/01_basic_digester.py"]

--- a/README.md
+++ b/README.md
@@ -260,6 +260,13 @@ See [Installation](docs/user_guide/installation.md).
 
 See [Quickstart](docs/user_guide/quickstart.md).
 
+### Interactive Examples (Google Colab)
+
+Try PyADM1 directly in your browser without any installation:
+
+*   **Basic Digester**: [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/dgaida/PyADM1ODE/blob/master/examples/colab_01_basic_digester.ipynb)
+*   **Complex Two-Stage Plant**: [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/dgaida/PyADM1ODE/blob/master/examples/colab_02_complex_plant.ipynb)
+
 ### Basic Usage
 ```python
 from pyadm1 import BiogasPlant

--- a/docs/assets/interrogate_badge.svg
+++ b/docs/assets/interrogate_badge.svg
@@ -1,5 +1,5 @@
 <svg width="140" height="20" viewBox="0 0 140 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <title>interrogate: 98.1%</title>
+    <title>interrogate: 97.2%</title>
     <g transform="matrix(1,0,0,1,22,0)">
         <g id="backgrounds" transform="matrix(1.32789,0,0,1,-22.3892,0)">
             <rect x="0" y="0" width="71" height="20" style="fill:rgb(85,85,85);"/>
@@ -12,8 +12,8 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
         <text x="590" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="610">interrogate</text>
         <text x="590" y="140" transform="scale(.1)" textLength="610">interrogate</text>
-        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">98.1%</text>
-        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">98.1%</text>
+        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">97.2%</text>
+        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">97.2%</text>
     </g>
     <g id="logo-shadow" serif:id="logo shadow" transform="matrix(0.854876,0,0,0.854876,-6.73514,1.732)">
         <g transform="matrix(0.299012,0,0,0.299012,9.70229,-6.68582)">

--- a/docs/de/examples/basic_digester.md
+++ b/docs/de/examples/basic_digester.md
@@ -1,8 +1,6 @@
 # Basis-Fermenter Beispiel
-n<div align="center">
-  <a href="https://colab.research.google.com/github/dgaida/PyADM1ODE/blob/master/examples/colab_01_basic_digester.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="In Google Colab öffnen (Basis)"></a>
-  <a href="https://colab.research.google.com/github/dgaida/PyADM1ODE/blob/master/examples/colab_02_complex_plant.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="In Google Colab öffnen (Komplex)"></a>
-</div>
+[![In Google Colab öffnen](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/dgaida/PyADM1ODE/blob/master/examples/colab_01_basic_digester.ipynb)
+
 
 Das Beispiel [examples/01_basic_digester.py](https://github.com/dgaida/PyADM1ODE/blob/master/examples/01_basic_digester.py) zeigt die einfachstmögliche PyADM1-Konfiguration: einen einzelnen Fermenter mit Substratzulauf und integriertem Gasspeicher.
 

--- a/docs/de/examples/two_stage_plant.md
+++ b/docs/de/examples/two_stage_plant.md
@@ -1,4 +1,6 @@
 # Zweistufige Biogasanlage Beispiel
+[![In Google Colab öffnen](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/dgaida/PyADM1ODE/blob/master/examples/colab_02_complex_plant.ipynb)
+
 
 Das Beispiel [examples/02_two_stage_plant.py](https://github.com/dgaida/PyADM1ODE/blob/master/examples/02_two_stage_plant.py) zeigt eine komplette zweistufige Biogasanlage mit mechanischen Komponenten, Energieintegration und umfassender Prozessüberwachung.
 

--- a/docs/en/examples/basic_digester.md
+++ b/docs/en/examples/basic_digester.md
@@ -1,4 +1,6 @@
 # Basic Digester Example
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/dgaida/PyADM1ODE/blob/master/examples/colab_01_basic_digester.ipynb)
+
 
 The [examples/basic_digester.py](https://github.com/dgaida/PyADM1ODE/blob/master/examples/01_basic_digester.py) example demonstrates the simplest possible PyADM1 configuration: a single digester with substrate feed and integrated gas storage.
 

--- a/docs/en/examples/two_stage_plant.md
+++ b/docs/en/examples/two_stage_plant.md
@@ -1,4 +1,6 @@
 # Two-Stage Biogas Plant Example
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/dgaida/PyADM1ODE/blob/master/examples/colab_02_complex_plant.ipynb)
+
 
 The [examples/two_stage_plant.py](https://github.com/dgaida/PyADM1ODE/blob/master/examples/02_two_stage_plant.py) example demonstrates a complete two-stage biogas plant with mechanical components, energy integration, and comprehensive process monitoring.
 


### PR DESCRIPTION
This PR adds Google Colab interactive badges to the README and documentation to make it easier for users to try PyADM1 directly in their browser. It also includes a Dockerfile for a standardized containerized simulation environment.

Key changes:
- Added "Interactive Examples (Google Colab)" section to README.md.
- Added Colab badges to German and English documentation for basic and complex plant examples.
- Created Dockerfile with Python 3.11 and Mono support.
- Updated documentation coverage badge.

---
*PR created automatically by Jules for task [7218378964454381733](https://jules.google.com/task/7218378964454381733) started by @dgaida*